### PR TITLE
Fix restart resuming into session "unknown"

### DIFF
--- a/metadev
+++ b/metadev
@@ -113,6 +113,10 @@ for c in cmds:
     if [ -f "$MARKER_FILE" ]; then
         RESUME_SID=$(cat "$MARKER_FILE")
         rm -f "$MARKER_FILE"
+        # SessionEnd hook writes "unknown" when it can't find a session file
+        if [ "$RESUME_SID" = "unknown" ]; then
+            RESUME_SID=""
+        fi
     fi
 
     # Build auto-continue prompt with reason and command output


### PR DESCRIPTION
## Summary
- When the SessionEnd hook can't find a `.jsonl` session file, it writes `"unknown"` to the marker file
- Metadev then passed `"unknown"` as a session ID to `claude --resume "unknown"`, producing a broken session
- Now treats `"unknown"` as empty so it falls through to a fresh start instead

## Test plan
- [ ] Run `/restart` with AWS login and verify the session starts fresh instead of resuming into "unknown"

🤖 Generated with [Claude Code](https://claude.com/claude-code)