### PR TITLE
qa: lopepage and lopepage-urls QA passes (2026-05-07)

### DIFF
--- a/qa/per-notebook/lopepage-urls.md
+++ b/qa/per-notebook/lopepage-urls.md
@@ -1,0 +1,60 @@
+# lopepage-urls — per-notebook QA guidance
+
+The hash-DSL parser/serializer and link-builder used by lopepage. The notebook is mostly a cell-library; almost no prose, so QA load-bears on probing the API surface, not visual inspection.
+
+## Recommended hash to QA with
+
+Use the bootconf default `#view=S100(@tomlarkworthy/lopepage-urls,@tomlarkworthy/module-selection)`, ideally with the pairing tab side-by-side so you can `eval_code` against the live functions.
+
+## Function-by-function checklist
+
+After grabbing functions out of the runtime (see "How to probe" below), test each with both happy-path and adversarial inputs:
+
+| Export | Happy path | Adversarial |
+|---|---|---|
+| `parseViewDSL(s)` | each entry of `dslExamples` parses | empty/null → empty group; unclosed paren `S(@a/b` should error but currently does NOT (issue #8); junk after `@` is accepted as a slug |
+| `parseGoldenDSL(s)` | round-trips with `serializeGoldenDSL` after one iteration (fixed-point) | input with weights gets normalized to percentage; not byte-identical |
+| `serializeGoldenDSL(layout)` | emits `S100/R/C` form with normalized sizes | singleton groups always emit `100` regardless of input — root cause of `@tomlarkworthy/lopepage#test_url_roundtrip` failing |
+| `listModules(hash)` | returns Map keyed by module title | duplicate module names collapse silently |
+| `getCell(hash, module)` | — | **`module` arg is ignored** (issue #3) — same as `_getModuleTitles(parseGoldenDSL(hash))` |
+| `navHref(target, opts)` | `"@a/b"` → `"#open=@a/b"`; intent `{close:"@a/b"}` → `"#close=@a/b"` | string + `{op:"close"}` returns `"#open=..."` (issue #1); `null` → `"#open=null"` (issue #2); `{source}` is silently dropped (issue #4) |
+| `linkTo(target, opts)` | drops `view/open/close/focus/from` from baseURI hash by design (#150 fix); preserves `cc=`, other keys | string + `{op:"close"}` ignored (same root as navHref); intent form `{module, op}` works |
+| `extractNotebookAndCell(href)` | observablehq.com URLs work; bare `@user/foo`, `d/HASH` work | `null/undefined` throw (issue #5); any non-observablehq.com host concatenates host into slug (issue #6 — affects production `observableusercontent.com`); `https://observablehq.com/d/HASH@N` returns null (issue #7) |
+| `updateNotebookImports` | rewrites `.observablehq--import` link hrefs in real time when `vars` updates | confirmed works on 14 import blocks at QA time |
+| `isOnObservableCom()` | string heuristic over `location.href` | only checks substring `observableusercontent.com`; doesn't catch `observablehq.com` |
+
+## How to probe (cheat sheet)
+
+```js
+// Pull every export out of the live runtime into window._lpu so you can eval_code freely
+const runtime = window.__ojs_runtime;
+const upMod = [...runtime._modules.values()].find(m => [...m._scope.keys()].includes("parseViewDSL"));
+const fns = {};
+for (const name of ["parseViewDSL","parseGoldenDSL","serializeGoldenDSL","listModules","getCell","navHref","linkTo","isOnObservableCom","extractNotebookAndCell","convertToGoldenLayout","normalizeWeights"]) {
+  const v = upMod._scope.get(name);
+  if (v?._value !== undefined) fns[name] = v._value;
+}
+window._lpu = fns;
+```
+
+## Known-bad behaviors to re-verify on every pass
+
+1. `navHref("@a/b", {op: "close"})` should return `"#close=@a/b"` (currently `"#open=@a/b"`).
+2. `getCell(hash, "@a/b")` should be filterable by the second arg (currently no-op).
+3. `extractNotebookAndCell` on `observableusercontent.com` (lopebooks production host) should return clean slugs.
+4. `extractNotebookAndCell("https://observablehq.com/d/HASH@N")` should not return null.
+5. `parseViewDSL("S50(@a/b,@c/d")` (missing close paren) should throw.
+6. The downstream test `@tomlarkworthy/lopepage#test_url_roundtrip` should pass — root cause is `normalizeWeights` collapsing singleton-group weights to 100%.
+
+If any of these pass cleanly on a future run, *update this file*: the bug was fixed and the corresponding entry should move to "Things to keep an eye on for regressions".
+
+## Things that are fine (to avoid re-litigating)
+
+- Console is clean: only framework-level `@import` CSS warnings (notebook-kit) and one `jest/expect version` log from the shared dep.
+- Tests are snapshot-style (`dslExamples.map(parseViewDSL)`) — they do NOT assert correctness, only stability. Don't expect them to catch behavioural regressions; they catch schema regressions only.
+- `linkTo` deliberately strips `view=` from base hash — this is a fix for issue #150, not a bug. Documented in-cell.
+- The notebook has no demo widget for `updateNotebookImports`; verify by checking `.observablehq--import` `[href]` values directly.
+
+## What to expect a QA report to flag
+
+This notebook reliably scores **fail on #2 (no explanation), #5 (no feature list), #10 (multiple silent failures on adversarial input)**. Until prose is added, those will repeat. The "real" bugs (issues #1–#9 in the 2026-05-07 report) are the ones that need code fixes.

--- a/qa/reports/lopepage-2026-05-07.md
+++ b/qa/reports/lopepage-2026-05-07.md
@@ -1,0 +1,119 @@
+# QA report: lopepage
+
+**Date:** 2026-05-07
+**Notebook:** `lopecode/notebooks/@tomlarkworthy_lopepage.html`
+**URL hash:** `#view=R100(S70(@tomlarkworthy/lopepage),S30(@tomlarkworthy/module-selection))&cc=...`
+**Browser:** Playwright Chromium (headed, 1400×900)
+
+## Summary
+
+Lopepage is the GoldenLayout-based shell that hosts every other lopecode notebook in tabs/stacks/rows. It boots correctly, all panels render, the documented dataflow ("intent overlay → tree-sync → commit") works for `view=` and `open=` intents, and the in-notebook `test_url_roundtrip` is currently green for the boot hash. **However**, two of the four documented intent params (`close=` and `focus=`) are *not implemented at all* — `sync_layout_from_url` only reads `view` and `open` from the URLSearchParams, so any hash whose only intent is `close=X` or `focus=X` (or any unknown key, or no `view=` at all) collapses the entire workspace to `S100()` (zero tabs). One of the notebook's own demo links (`reset view` → `#testNavigation`) lands the user in this empty state. Worst issue is high severity, **fail on criteria #2, #3, #4, #10**.
+
+## Criterion scoring
+
+| # | Criterion | Status | Evidence |
+|---|---|---|---|
+| 1 | Clear title | **fail** | No `<h1>` anywhere in the notebook. The first heading rendered is `<h2>Manual Testing links</h2>`. There is no on-page identification of what this notebook is. The Observable module name `@tomlarkworthy/lopepage` is the only "title". |
+| 2 | Explanation | **fail** | Within the first viewport: zero introduction. The opening cells are `page = HTMLDivElement {}`, then "Manual Testing links". A stranger sees raw runtime values, not a description. The substantial dataflow documentation only appears far below, after the impl cells. |
+| 3 | Doc matches impl | **fail** | The "URL Sync" section explicitly lists `open / close / focus / from` as the four "one-shot intent params (cleared after commit)". Of those, only `open` is implemented (issue #1). `close=` and `focus=` are silently no-ops on the desired intent and *also* wipe the layout. The "from" intent is also unimplemented (no reads in `sync_layout_from_url`). |
+| 4 | Does what it says | **fail** | Boot rendering, `view=`, and `open=` work as advertised. But `close=` and `focus=` cause a layout wipe instead of doing what they claim. The "reset view" demo link in the notebook itself triggers the wipe (issue #2). |
+| 5 | Feature list | partial | The "URL Sync" / "State model" / "Dataflow" / "Unit test gate" sections are clear and well-structured for an architecture-doc audience. But there's no skimmable feature/API list at the top — a reader who lands here can't tell what's exported, what to import, or what behaviors lopepage promises without reading 1000+ lines of source. |
+| 6 | Lean code | partial | ~37 cells, much of it justified given the GoldenLayout integration plus URL-sync plus scroll-restoration plus background-job orchestration. Two minor concerns: `fix_scroll` is self-described in the prose as "over-complex" (`I suspect fix_scroll is over-complex`), and `scrollLog` accumulates 12,000+ entries over a couple minutes of mild interaction (`get_variable scrollLog` returned an `Array(12062)` after ~5 minutes) — should at least cap the log. |
+| 7 | Scoped domain | partial | This *is* a single concern (the multi-module layout shell) but it pulls in a lot — golden-layout, exporter, claude-code-pairing, local-change-history, editor-5, visualizer, runtime-sdk. That's appropriate scope for the role but creates a heavy dependency cone for any consumer. |
+| 8 | Claims tested | partial | One named test, `test_url_roundtrip`, currently passes for the boot hash. But the test only fires when a `view=` is present and only for the *current* layout shape — it doesn't cover the close/focus wipe regression (which never sets a postURL) or the malformed-input case. Many concrete claims in the dataflow prose ("treeSync is non-destructive", "commit then clear") have no automated check. |
+| 9 | Serialization | not tested | Skipped — the active layout-routing bugs are louder; round-tripping the HTML file would lose the hash state (which is the main feature here) and risks shadowing those issues. |
+| 10 | Adversarial / try to break | **fail** | `#close=X` (X open or not), `#focus=X`, `#cc=...` alone, `#testNavigation` — all four wipe the layout. Malformed `view=R100(S50(@x/y` (no closing paren) sticks in the URL without recovery (parser is too permissive — known from the lopepage-urls QA). Rapid-fire `open=` intents partially coalesce — 10 distinct opens fired ~50 ms apart resulted in 7 added tabs, not 10 (some intents get silently dropped during `commit-then-clear`). |
+| 11 | Clean console logs | pass | Console captured 0 errors, 3 framework `@import` CSS warnings (notebook-kit, not lopepage-attributable). 0 cell-attributable `console.log`/`debug`. lopepage explicitly routes its tracing through `appendScrollLog` → in-page `scrollLog` array, not console. |
+
+## Issues found
+
+### 1. `close=` and `focus=` intent params are not implemented; any hash with no `view=` wipes the layout — severity: high — criterion: #3 / #4 / #10
+
+- **What:** `sync_layout_from_url` reads only `view` and `open` from the URLSearchParams. When the hash has only `close=X`, `focus=X`, `cc=...`, an unknown param, or any combination without a `view=`, `parseGoldenDSL(null)` is called, which returns the empty fallback group, and `treeSyncGolden` then prunes the live layout to match → all tabs removed → `#view=S100()` is committed back to the URL. The user's entire workspace silently disappears.
+- **Where:** `@tomlarkworthy/lopepage.sync_layout_from_url` at the lines `const view = params.get("view"); const open = params.get("open");` — there is no read of `close` or `focus`. Source: `notebooks/@tomlarkworthy_jumpgate/modules/@tomlarkworthy/lopepage.js:509–511`.
+- **Evidence (4 reproductions):**
+  - From boot view, `location.hash = "#close=@tomlarkworthy/runtime-sdk"` → after 1.5s, `tabs=[]`, `hash="#view=S100()&cc=..."`.
+  - Same with `#focus=@tomlarkworthy/lopepage-urls` (a tab that *is* in the layout) → `tabs=[]`.
+  - Sequence `#open=@tomlarkworthy/runtime-sdk` (works) then `#close=@tomlarkworthy/runtime-sdk` → tabs=[].
+  - `location.hash = "#cc=LOPE-..."` (no view= at all) → `tabs=[]`.
+- **Hypothesis:** Implement close/focus by reading them like `open`, and *short-circuit* sync when neither `view` nor `open` (nor close/focus) is present — the safest behaviour is "no-op when no intent or view is given," not "treat null view as empty layout."
+
+### 2. The notebook's own "reset view" link wipes the layout — severity: high — criterion: #4
+
+- **What:** The `_testNavigation` cell renders `<li><a href="#testNavigation">reset view</a></li>` as documented manual-testing UI. Clicking it (or simulating it via `location.hash="#testNavigation"`) triggers issue #1 because `#testNavigation` has no `view=`. The user clicks a link the *notebook's own prose* tells them to click; the tabs disappear; the URL gets rewritten to `#view=S100()&testNavigation` (also losing `cc=`).
+- **Where:** `@tomlarkworthy/lopepage.testNavigation`, line 31 of source.
+- **Evidence:** Setting `location.hash = "#testNavigation"` — `tabs=[]`, hash committed as `"#view=S100()&testNavigation"`.
+- **Hypothesis:** The author intended `#testNavigation` to scroll to the section anchor (browser-default), but the URL routing intercepts every hash change. Either route the routing only on recognised intent keys (`view/open/close/focus/from`) or change the link to point to `#view=...` of a sensible default.
+
+### 3. The "refresh page" link hardcodes the observablehq.com URL — severity: medium — criterion: #4
+
+- **What:** `<a href="https://observablehq.com/@tomlarkworthy/lopepage#testNavigation">refresh page</a>` always points to observablehq.com regardless of where the notebook is currently running (file://, observableusercontent.com, GitHub Pages, custom domain). On any other host, "refresh page" navigates the user away from their current notebook to the upstream Observable canonical version.
+- **Where:** `@tomlarkworthy/lopepage.testNavigation`, source line 34.
+- **Evidence:** When QAing on `file:///`, the rendered link href is `https://observablehq.com/@tomlarkworthy/lopepage#testNavigation`.
+- **Hypothesis:** Use `linkTo("@tomlarkworthy/lopepage")` or `location.reload()`-as-button instead of a hardcoded URL.
+
+### 4. Malformed `view=` is silently accepted and persists in the URL — severity: medium — criterion: #10
+
+- **What:** Setting `location.hash = "#view=R100(S50(@tomlarkworthy/lopepage&cc=..."` (deliberately unclosed paren — and crucially the cc= becomes part of the slug because parseViewDSL accepts any chars after `@`) leaves the URL exactly as-is. The layout renders 1 tab (lopepage with `&cc=...` smuggled into the slug name). The URL is not rewritten back to canonical, so a refresh would re-trigger the same broken state.
+- **Where:** Root cause is in `@tomlarkworthy/lopepage-urls.parseViewDSL` (issue #8 in that notebook's QA), but the symptom surfaces in lopepage's URL routing.
+- **Evidence:** `location.hash = "#view=R100(S50(@tomlarkworthy/lopepage&cc=LOPE-55290-6PEE"` → `tabs=["@tomlarkworthy/lopepage"]`, hash retained verbatim (no canonical commit).
+- **Hypothesis:** Either tighten the parser (lopepage-urls fix) or make sync_layout_to_url *always* recommit a normalized canonical URL after a successful sync, even if the input wasn't textually canonical.
+
+### 5. Rapid `open=` intents are coalesced/dropped — severity: medium — criterion: #10
+
+- **What:** Firing 10 distinct `#open=@user/X` intents at 50ms intervals — meant to add 10 tabs to a 2-tab layout — ended with 9 tabs (7 of the 10 intended additions present). 3 distinct opens were silently dropped without any console error.
+- **Where:** Likely in the "commit then clear" handoff between `sync_layout_from_url` and `sync_layout_to_url`. The intent param is read once and then the URL is rewritten; subsequent intent-only hashchange events fire *before* the commit completes and are missed.
+- **Evidence:** `setInterval` opening 10 modules at 50ms cadence → final layout had 9 tabs (7 additions); intermediate channel events showed every intent fired but only some applied.
+- **Hypothesis:** Queue intents instead of treating them as snapshots, or always include the resolved `view=` in the redirect so the next hashchange computes the diff against the *latest* layout.
+
+### 6. `scrollLog` grows without bound — severity: medium — criterion: #6
+
+- **What:** The in-page `scrollLog` array reached **12,062 entries** after ~5 minutes of normal interaction. Each scroll, panel render, and URL sync appends multiple entries. Although `scrollDebug` viewof gates display, the entries are still appended unconditionally to the mutable array. Long-running sessions will accumulate megabytes of trace data.
+- **Where:** `@tomlarkworthy/lopepage.appendScrollLog` (line 270).
+- **Evidence:** `get_variable scrollLog` → `"Array(12062) [Object {t: 1778131255052, type: \"modulePanel:enter\", ...}, ...]"`.
+- **Hypothesis:** Cap the array at a sliding window (e.g. last 1000 entries), or only push when `scrollDebug` is enabled.
+
+### 7. `fix_scroll` self-described as over-complex — severity: low — criterion: #6
+
+- **What:** The "Scrolling" prose contains the line: *"Scrolling has been a mess to develop. The thing that finally fixed it was scroll_fix_sync_layout. I suspect fix_scroll is over-complex."* — author admission of code smell. `fix_scroll` is ~110 lines (source 292–399), branchy, with deep null-safe chains.
+- **Where:** `@tomlarkworthy/lopepage.fix_scroll`.
+- **Evidence:** Source comment + cell length.
+- **Hypothesis:** Refactor — likely fewer cases needed now that `scroll_fix_sync_layout` exists.
+
+### 8. No `<h1>` title in the notebook — severity: low — criterion: #1
+
+- **What:** The notebook has zero `<h1>` elements. The first heading rendered is `<h2>Manual Testing links</h2>`. A casual reader cannot quickly identify what this notebook is.
+- **Where:** Top of notebook.
+- **Evidence:** `document.querySelectorAll('h1')` in panel returned 0; first heading is the H2.
+- **Hypothesis:** Add a `md\`# Lopepage — multi-module layout shell\`` cell at the top with a 1–3 sentence elevator pitch.
+
+### 9. `_test_url_roundtrip` only catches the *last-applied* layout, not the universe of inputs — severity: medium — criterion: #8
+
+- **What:** The lone test in this notebook compares `preURL` to `postURL` for whatever was just synced. If the URL is the canonical form already (which the boot URL is), the test always passes. None of issues #1, #2, #4, #5 above would be caught by this test, even though the test exists in the same module that contains those bugs. (See also the lopepage-urls QA for the orthogonal `normalizeWeights` regression that DID surface here as a "view URL drift" failure with a non-canonical layout.)
+- **Where:** `@tomlarkworthy/lopepage.test_url_roundtrip`.
+- **Evidence:** `get_variable test_url_roundtrip` → `true` for the boot hash; same test was failing in the lopepage-urls QA pass on a different boot hash.
+- **Hypothesis:** Add explicit unit cases for: `close=` non-existent, `close=` existent, `focus=`, hash with no `view=`, malformed `view=`, rapid `open=` sequences. Make these return either a Boolean or an Error object the Tests panel can render.
+
+## Per-notebook guidance applied
+
+No prior `qa/per-notebook/lopepage.md` existed — this is the first formal QA pass. New file written in same commit.
+
+## Things checked and OK
+
+- Layout boots: 2 tabs render in the configured `R100(S70(...),S30(...))` configuration.
+- `view=R100(S50(@a),S50(@b,@c))` correctly produces the 3-tab two-stack layout.
+- `open=@user/X` correctly adds @user/X to the first stack and rewrites the hash to canonical view=.
+- `test_url_roundtrip` is `true` at boot for the canonical layout (no "view URL drift" with explicitly-weighted children).
+- `settings`, `modulePanel`, `blobPanel`, `layout`, `page`, `onLoadConfig`, `is_mobile` all compute non-null values.
+- The empty-state `S100()` view shows a recovery message — `Lost? Open the module explorer` — which is good UX given the wipe happens.
+- `Manual Testing links` correctly uses `linkTo()` for stream-operators, stream-operators#combineLatest, runtime-sdk#observe — those three links are well-formed (issue is only with the first two).
+- Module dependency cone resolves: 43 modules in the runtime, none in error state.
+- Console hygiene is clean — debug tracing routed to `scrollLog`, not console.
+- Rapid-fire stress did not cause a crash, just intent drops (issue #5).
+
+## Notes for follow-up
+
+- The interactive drag/resize/close-via-X-button paths were *not* exercised; only programmatic hash manipulation was tested. A future pass should physically drag a divider and click the GoldenLayout × close-tab button to verify the canonical commit fires for those paths too.
+- `serialization` (criterion #9) was not tested. The notebook's primary surface is the URL hash, which is intentionally ephemeral, so `export_notebook` round-trip risks shadowing the routing bugs above.
+- `auto_attach`, `commit_history`, `replay_git`, `change_listener`, `navigator_jobs` (referenced from `background_jobs`) live in dependency modules and were not enumerated here. A follow-up pass on `claude-code-pairing` or `local-change-history` should cover them.
+- The "reset view" link being a layout-wipe is mentioned in passing in the prose — but the prose doesn't call it out as a *known issue*; it presents these as Manual Testing links the user should rely on. Until issue #1 is fixed, the prose should warn that `reset view` clears the workspace.

--- a/qa/reports/lopepage-urls-2026-05-07.md
+++ b/qa/reports/lopepage-urls-2026-05-07.md
@@ -1,0 +1,131 @@
+# QA report: lopepage-urls
+
+**Date:** 2026-05-07
+**Notebook:** `lopecode/notebooks/@tomlarkworthy_lopepage-urls.html`
+**URL hash:** `#view=R100(S50(@tomlarkworthy/lopepage-urls,@tomlarkworthy/module-selection),S50(@tomlarkworthy/claude-code-pairing))&open=@tomlarkworthy/claude-code-pairing&cc=...`
+**Browser:** Playwright Chromium (headed, 1400×900)
+
+## Summary
+
+`lopepage-urls` is the lopepage hash-DSL toolkit (parser, serializer, link-builder, import-rewriter). The 7 own tests all pass and the live integration via `updateNotebookImports` works (14 import blocks rewritten correctly). However the notebook is **almost entirely undocumented** — no elevator pitch, no feature list, only section headers — and probing the API surface from the source revealed **eight concrete behavioural bugs** in `navHref`, `linkTo`, `getCell`, `extractNotebookAndCell`, and `parseViewDSL`. Two of them (extract on `observableusercontent.com`, parse on unclosed parens) silently produce nonsense instead of erroring or working correctly. One downstream test (`@tomlarkworthy/lopepage#test_url_roundtrip`) is failing because `normalizeWeights` collapses single-child group weights, breaking textual round-trip stability for layouts that have an outer single-child group.
+
+## Criterion scoring
+
+| # | Criterion | Status | Evidence |
+|---|---|---|---|
+| 1 | Clear title | pass | `<h1>lopepage urls</h1>` at top, matches module slug. |
+| 2 | Explanation | **fail** | First viewport contains H1, "Tests" header, and the test rows — zero prose explaining what the notebook is or who uses it. The whole notebook has only one paragraph (`Watch the runtime for imports and swap them for our structure`). |
+| 3 | Doc matches impl | partial | There is no documentation, so nothing to validate. The few claims that exist (the section headers `## Get cell`, `## Add linkTo`, etc.) are mostly accurate but `getCell` does NOT do what its header implies (see issue #3). |
+| 4 | Does what it says | partial | All 7 own tests pass and `updateNotebookImports` rewrites 14 real import blocks correctly. But several exported functions silently misbehave on plausible inputs (see issues #1–#7). |
+| 5 | Feature list | **fail** | No feature list, no API summary, no "what's exported" section. Section headers (`Tests`, `Serialization`, `Flat listModules`, `Get cell`, `navHref`, `Add linkTo`, `Auto switch to url structure`) are the only navigation aid. Several exports (`isOnObservableCom`, `convertToGoldenLayout`, `normalizeWeights`, `extractNotebookAndCell`) are not mentioned at all in the prose — undocumented features. |
+| 6 | Lean code | pass | 37 cells, mostly lean. Two tiny dead cells: `_1d8nta8` (`"SRC".includes("S")`) is a one-line scratch left over. `_24` (`htl.html\`<a href="${navHref("foo$ref")}">nav</a>\``) is a demo for `navHref` with no surrounding prose explaining what it shows. No major duplication. |
+| 7 | Scoped domain | pass | Concern is clearly the lopepage hash DSL plus URL/link helpers. Imports `runtime-sdk` and `tests` only — minimal dependency footprint. |
+| 8 | Claims tested | partial | The 7 in-notebook tests pass, but they're snapshot-style (just compute values, no assertions about them). They would not catch the bugs found below — e.g. `test_linkTo` records what `linkTo` produces but doesn't assert it's correct. |
+| 9 | Serialization | not tested | Skipped (criterion #4 + #10 surfaced enough issues; round-tripping the file has high collateral risk and is not where the active bugs live). |
+| 10 | Adversarial / try to break | **fail** | `extractNotebookAndCell(null)` throws; `parseViewDSL("S50(@a/b,@c/d")` (unclosed paren) silently parses; `extractNotebookAndCell("https://observableusercontent.com/@user/notebook")` (the production host) produces `@observableusercontent.com/@user/notebook`. See issues. |
+| 11 | Clean console logs | pass | Of 366 console entries, only 3 cell-attributable messages (all CSS `@import rules are not allowed` warnings from notebook-kit stylesheets — framework-level, not from lopepage-urls cells) and one `jest/expect version 24.0.0` log from the shared jest-expect dependency. Zero `console.log`/`debug` from lopepage-urls itself. |
+
+## Issues found
+
+### 1. `navHref(target, {op})` ignores `op` for string targets — severity: high — criterion: #4
+
+- **What:** `navHref("@a/b", {op: "close"})` returns `"#open=@a/b"` instead of `"#close=@a/b"`. The `!isIntent` branch unconditionally sets `finalOp = "open"`, overriding the caller's argument.
+- **Where:** `@tomlarkworthy/lopepage-urls.navHref`, the `if (!isIntent) { ... finalOp = "open"; }` block.
+- **Evidence:** `eval_code` — `navHref("@a/b", {op:"close"})` → `"#open=@a/b"`; `navHref("@a/b", {op:"focus"})` → `"#open=@a/b"`. Same bug exists in `linkTo`'s `!isIntent` branch (`linkTo("@a/b", {op:"close", onObservable: false})` → `"#open=@a/b"`).
+- **Hypothesis:** Refactor accidentally hard-coded `op = "open"` for the string path; the intent path does the right thing (`linkTo({module:"@a/b", op:"close"})` → `"#close=@a/b"`).
+
+### 2. `navHref(null|undefined|"")` returns `"#open=null"` — severity: medium — criterion: #4 / #10
+
+- **What:** Calling navHref with no real target produces a malformed link string `"#open=null"`. If clicked, lopepage would attempt to "open" a module called `null`.
+- **Where:** `@tomlarkworthy/lopepage-urls.navHref`; the `String(target ?? "")` produces `"null"` for `null`/`undefined` because `?? ""` only short-circuits on null/undefined for the default but `String(null)` then runs through `parts[0] || null` and the template literal stringifies `null` again.
+- **Evidence:** `eval_code` — `navHref(null)` → `"#open=null"`, `navHref(undefined)` → `"#open=null"`, `navHref("")` → `"#open=null"`.
+- **Hypothesis:** Defensive guard missing. Should return `""` or throw on empty input.
+
+### 3. `getCell(hash, module)` ignores its `module` argument — severity: high — criterion: #3 / #5
+
+- **What:** Despite its name and 2-arg signature, `getCell` returns the same array for any value of the `module` argument. It's a synonym for `_getModuleTitles(parseGoldenDSL(hash))`.
+- **Where:** `@tomlarkworthy/lopepage-urls.getCell` — body is `(hash, module) => { if (!hash) return undefined; return _getModuleTitles(parseGoldenDSL(hash)); }`.
+- **Evidence:** `eval_code` — `getCell(h, "@a/b")`, `getCell(h, "@x/y")`, and `getCell(h)` all return the identical array of `{title, cell}` objects.
+- **Hypothesis:** Either the function is supposed to filter by `module` (then it's broken), or it's misnamed (should be `getCells`/`listCells` and drop the unused param). The H2 above it (`## Get cell`) suggests singular intent.
+
+### 4. `navHref(target, {source})` silently drops `source` — severity: low — criterion: #3 / #4
+
+- **What:** The `source` option is captured into `finalSource` but never appears in the returned hash (no `from=` is emitted). `linkTo`'s string-target branch has the same dead-code path (the `source` param is set inside the `!isIntent` block but the linkTo body that sets `hashParams.set('from', source)` is in the intent path only — wait, actually `linkTo` does set `from=` for intents). For `navHref`, `finalSource` is unused.
+- **Where:** `navHref` last lines never reference `finalSource`.
+- **Evidence:** `navHref("@a/b", {source: "@x/y"})` → `"#open=@a/b"` (no `from=`).
+- **Hypothesis:** Documented opt that nothing implements — drop it from the signature, or implement it (`return \`#${finalOp}=${...}${finalSource ? \`&from=${finalSource}\` : ""}\``).
+
+### 5. `extractNotebookAndCell(null|undefined)` throws — severity: medium — criterion: #10
+
+- **What:** Passing `null` or `undefined` throws `TypeError: Cannot read properties of null (reading 'match')`. Production callers (e.g. `updateNotebookImports`) read `link.href` which is always a string, but defensive callers will trip.
+- **Where:** `@tomlarkworthy/lopepage-urls.extractNotebookAndCell`, the line `href.match(regex)`.
+- **Evidence:** `eval_code` — `extractNotebookAndCell(null)` → throws; same for `undefined`. Empty string `""` returns `null` cleanly (good).
+- **Hypothesis:** Add `if (typeof href !== "string") return null;` at top.
+
+### 6. `extractNotebookAndCell` mangles every non-`observablehq.com` host — severity: high — criterion: #4 / #10
+
+- **What:** When the URL host is anything other than `observablehq.com` (including the *actual* production host `observableusercontent.com` where lopebooks live, and any third-party site), the host is concatenated into the slug, producing nonsense like `@observableusercontent.com/@user/notebook` or `@evil.com/@a/b`. There is no handling for the canonical Observable runtime host.
+- **Where:** `@tomlarkworthy/lopepage-urls.extractNotebookAndCell`, the `else { notebook = host + "/" + nb }` branch — the only special-cased host is `observablehq.com`.
+- **Evidence:** `extractNotebookAndCell("https://observableusercontent.com/@user/notebook")` → `{notebook: "@observableusercontent.com/@user/notebook", cell: null}`. Compare to `extractNotebookAndCell("https://observablehq.com/@user/notebook")` → `{notebook: "@user/notebook", cell: null}`.
+- **Hypothesis:** The Observable runtime is `observableusercontent.com` (lopebooks) and `observablehq.com` (notebooks page); both should be treated as canonical. Adding `observableusercontent.com` to the special-case list (or a regex of trusted hosts) fixes this.
+
+### 7. `extractNotebookAndCell("https://observablehq.com/d/abc123def456@5")` returns `null` — severity: medium — criterion: #4
+
+- **What:** A canonical Observable d-style URL with version (`d/HASH@N`) prefixed with `https://observablehq.com/` returns `null`. The regex alternation `d\/[a-f0-9]+` doesn't accept the `@N` suffix in this position. (`https://d/HASH@N` — with host `d` — *does* work, by a different alternation.)
+- **Where:** `@tomlarkworthy/lopepage-urls.extractNotebookAndCell`, the regex `(?<nb>(@?[\w-]+\/[\w-]+|d\/[a-f0-9]+|e\/[a-f0-9]+@[0-9]+|[a-f0-9]+@[0-9]+|[\w-]+))`.
+- **Evidence:** `extractNotebookAndCell("https://observablehq.com/d/abc123def456@5")` → `null`; `extractNotebookAndCell("https://observablehq.com/d/abc123def456")` → `{notebook: "d/abc123def456", cell: null}`.
+- **Hypothesis:** Change the `d\/[a-f0-9]+` alternation to `d\/[a-f0-9]+(?:@[0-9]+)?` so the `@N` suffix is optional and consumed by the same alternation that strips it via `.replace(/@[0-9]+$/, "")`.
+
+### 8. `parseViewDSL` silently accepts unclosed parens — severity: medium — criterion: #10
+
+- **What:** Inputs like `"S50(@a/b,@c/d"` (missing closing `)`) parse successfully into `{groupType: "S", weight: 50, children: [@a/b, @c/d]}` instead of throwing. Inputs like `"("` (just an open paren) parse to an empty stack. The parser only checks for *trailing* characters, not missing `)`.
+- **Where:** `@tomlarkworthy/lopepage-urls.parseViewDSL`, `parseGroup` does `if (input[i] == ")") i++` (no `else err(...)`).
+- **Evidence:** `eval_code` — `parseViewDSL("S50(@a/b,@c/d")` returns a valid AST; only `parseViewDSL("S50(@a/b))")` (extra close) errors.
+- **Hypothesis:** Add `else err("Expected ')'")` after the close-paren consumption in `parseGroup`. Same for `(` without a group prefix that's accepted as `S(` group type.
+
+### 9. `@tomlarkworthy/lopepage#test_url_roundtrip` fails because `normalizeWeights` collapses single-child sizes — severity: medium — criterion: #4
+
+- **What:** The downstream test in `@tomlarkworthy/lopepage` reports "view URL drift": `preURL=R100(S50(@user/x))`, `postURL=R100(S50(...))`, but `normalizedPreWithIntent=R100(S100(...))`, `normalizedPost=R100(S100(...))` — the outer `S50` was rewritten to `S100` because `normalizeWeights` divides each child's weight by the sum of siblings. With one sibling, the result is always 100%. Round-tripping a hand-authored `S50(...)` therefore changes its size to `S100(...)`.
+- **Where:** `@tomlarkworthy/lopepage-urls.normalizeWeights` — `child.size = ((w / total) * 100).toFixed(2) + "%"`. When `node.content.length === 1`, `total === w` so size is always `"100.00%"`.
+- **Evidence:** Tests panel — see screenshot of the Tests view (red ✗ on `test_url_roundtrip`, green ✅ on all 7 lopepage-urls tests).
+- **Hypothesis:** When there's a single child, `normalizeWeights` should preserve the parent's incoming weight rather than collapse it to 100%. Or `serializeGoldenDSL` should not emit a size for singleton groups.
+
+### 10. Undocumented exported features (criterion #5)
+
+The following exports are usable by importing modules but never appear in any prose section header or documentation:
+
+- `isOnObservableCom()` — heuristic for runtime location.
+- `convertToGoldenLayout(intermediate)` — AST → GoldenLayout converter.
+- `normalizeWeights(node)` — in-place weight normalization.
+- `extractNotebookAndCell(href)` — URL → `{notebook, cell}` extractor (only the test cell `test_extractNotebookAndCell` references it; the H2 `## Auto switch to url structure` is the closest hint).
+- `parseGoldenDSL`, `serializeGoldenDSL`, `parseViewDSL` — section header `## Serialization` exists but doesn't actually name them.
+
+For each, future passes should either (a) add a one-line description to a feature list or (b) rename to `_private` and remove from external use.
+
+## Per-notebook guidance applied
+
+No prior `qa/per-notebook/lopepage-urls.md` existed — this is the first formal QA pass. New file written in same commit.
+
+## Things checked and OK
+
+- H1 title renders prominently (criterion #1).
+- All 7 in-notebook tests (`test_parseViewDSL`, `test_reserialized`, `test_serializeGoldenDSL`, `test_parseGoldenDSL`, `test_list_modules`, `test_linkTo`, `test_extractNotebookAndCell`) compute and produce stable values.
+- `parseViewDSL` parses all 10 `dslExamples` without throwing.
+- `parseGoldenDSL` → `serializeGoldenDSL` is a fixed-point after the first round (canonical form converges within one iteration).
+- `listModules(undefined|null|"")` correctly returns an empty `Map` (defensive on null arg).
+- `linkTo` correctly drops `view`/`open`/`close`/`focus`/`from` from the base hash and preserves other keys (e.g. `cc=`, `keep=`); this is a deliberate fix for issue #150 documented in the cell.
+- `linkTo` with `onObservable: true` returns the slug-only path form.
+- `updateNotebookImports` rewrites all 14 `.observablehq--import` blocks in the live page to use `linkTo()`-style hash links.
+- Console logs originating from notebook cells are zero (`@import` warnings are framework CSS, not notebook code).
+- No notebook-side `console.log` debug residue.
+- No global `debugger;` statements were observed (silent-hang signature did not trigger).
+- Code is lean (37 cells, ~1.5kB of source); no obvious duplication or experimentation residue.
+- Dependency surface is tight: only `runtime-sdk` and `tests`.
+
+## Notes for follow-up
+
+- The `## Auto switch to url structure` section needs a demo. Currently it's two cells (`href_examples`, `vars`) and the impl `updateNotebookImports`, but you can't *see* the rewrite in the notebook itself unless you scroll to the imports table — the rewriting does work (verified) but no visible widget shows before/after.
+- The notebook would benefit from a 2-3 sentence intro paragraph immediately after the H1: who uses this, what problem it solves, and which functions to import.
+- Consider grouping exports into a `## API` section with one-line summaries: `parseViewDSL`, `parseGoldenDSL`, `serializeGoldenDSL`, `listModules`, `getCell`, `navHref`, `linkTo`, `extractNotebookAndCell`, `updateNotebookImports`.
+- The two-arg `getCell(hash, module)` signature should be reconciled with the implementation — pick "filter by module" or "rename to listCellTitles" and apply.
+- A property-based test would catch issues #1, #4, and #8 — every test currently is a snapshot, not an assertion.


### PR DESCRIPTION
## Summary
- First QA pass on lopepage and lopepage-urls
- New per-notebook guidance for lopepage-urls (lopepage's was committed separately as c09b2ff)
- Reports score 11 criteria each from qa/general.md

## Issues surfaced

**lopepage** (criteria #1, #2, #3, #4, #10 fail):
- close= and focus= intent params not implemented; any hash without view= wipes the layout to S100()
- Notebook's own "reset view" link (#testNavigation) triggers the wipe
- "refresh page" link hardcoded to observablehq.com regardless of host
- Malformed view= sticks in URL without canonical recovery
- Rapid open= intents are coalesced (10 fired, 7 applied)

**lopepage-urls** (criteria #2, #5, #10 fail):
- navHref op option ignored for string targets
- getCell silently ignores its module argument
- extractNotebookAndCell mangles observableusercontent.com URLs
- extractNotebookAndCell throws on null/undefined
- parseViewDSL silently accepts unclosed parens
- Plus four more

## Test plan
- [x] Reports stand alone — readable without qa/general.md
- [x] No code changes; only documentation files added