### PR TITLE
editor-5: drag the hotbar to reorder cells

### DIFF
--- a/modules/@tomlarkworthy/editor-5.js
+++ b/modules/@tomlarkworthy/editor-5.js
@@ -146,7 +146,7 @@ lookupVariable(
   editorModule
 )
 )};
-const _1q95xt6 = function _cellEditor(cloneDataflow,editorTemplate,shellTemplate,getOption,Event,setOption,createCell,findCell,pinOnCreate){return(
+const _1q95xt6 = function _cellEditor(cloneDataflow,editorTemplate,shellTemplate,getOption,Event,setOption,createCell,findCell,pinOnCreate,dragReorder){return(
 (variable, {
     pinned = undefined
 } = {}) => {
@@ -235,6 +235,20 @@ const _1q95xt6 = function _cellEditor(cloneDataflow,editorTemplate,shellTemplate
                             createCell({ cell: findCell(variable) });
                         });
                         hotbar.prepend(add);
+                    }
+                    // Drag the whole hotbar to reorder this cell (alternative to up/down arrows).
+                    if (hotbar && !hotbar.dataset.reorderable) {
+                        hotbar.dataset.reorderable = '1';
+                        hotbar.style.cursor = 'grab';
+                        const grip = document.createElement('span');
+                        grip.className = 'reorder-grip';
+                        grip.textContent = '⠿'; // ⠿ drag handle
+                        grip.title = 'Drag to reorder cell';
+                        // Float left so the grip sits at the far edge of the full-width
+                        // bar, while ➕/edit stay right-aligned via the shell's text-align.
+                        grip.style.cssText = 'float: left; margin-left: 4px; opacity: 0.55;';
+                        hotbar.prepend(grip);
+                        dragReorder(variable, hotbar);
                     }
                     if (body)
                         syncOpen();
@@ -728,6 +742,183 @@ async (cell, amount) =>
     }
   })
 )};
+const _mvbs01 = function _moveCellBeside($0){return(
+async (cell, target, placeAfter = false) =>
+  $0.send({
+    command: "moveCellBeside",
+    args: {
+      cell,
+      target,
+      placeAfter
+    }
+  })
+)};
+const _drag01 = function _dragReorder(runtime,divToVar,findCell,moveCellBeside){return(
+(variable, handle) => {
+  if (!document.getElementById('lope-reorder-style')) {
+    const s = document.createElement('style');
+    s.id = 'lope-reorder-style';
+    s.textContent =
+      'body.lope-reordering, body.lope-reordering * { user-select: none !important; cursor: grabbing !important; }';
+    document.head.appendChild(s);
+  }
+
+  const THRESH = 5;
+  let pointerId = null, dragging = false, startX = 0, startY = 0;
+  let cells = null, ownIndex = -1, scroller = null, indicator = null;
+  const blockSelect = (ev) => ev.preventDefault();
+
+  // Same-module visible cells in DOM order; one entry per rendered .observablehq div.
+  const getModuleCells = () => {
+    const mod = variable._module;
+    const out = [];
+    for (const div of document.querySelectorAll('.observablehq')) {
+      const v = divToVar(runtime, div);
+      if (v && v._module === mod) out.push({ div, v });
+    }
+    return out;
+  };
+
+  const ensureIndicator = () => {
+    if (indicator) return indicator;
+    indicator = document.createElement('div');
+    indicator.style.cssText =
+      'position: fixed; height: 0; z-index: 2147483646; pointer-events: none;' +
+      'border-top: 2px solid var(--theme-foreground-focus, #3b5bdb);';
+    document.body.appendChild(indicator);
+    return indicator;
+  };
+  const removeIndicator = () => { if (indicator) { indicator.remove(); indicator = null; } };
+
+  // gap 0..N: how many cells sit above pointer Y (by their vertical midpoint).
+  const gapAt = (y) => {
+    for (let i = 0; i < cells.length; i++) {
+      const r = cells[i].div.getBoundingClientRect();
+      if (y < r.top + r.height / 2) return i;
+    }
+    return cells.length;
+  };
+
+  const drawIndicator = (g) => {
+    const ind = ensureIndicator();
+    const ref = cells[Math.min(ownIndex, cells.length - 1)].div.getBoundingClientRect();
+    const y = g < cells.length
+      ? cells[g].div.getBoundingClientRect().top
+      : cells[cells.length - 1].div.getBoundingClientRect().bottom;
+    ind.style.left = ref.left + 'px';
+    ind.style.width = ref.width + 'px';
+    ind.style.top = (y - 1) + 'px';
+  };
+
+  const autoScroll = (y) => {
+    if (!scroller) return;
+    const r = scroller.getBoundingClientRect
+      ? scroller.getBoundingClientRect()
+      : { top: 0, bottom: window.innerHeight };
+    const M = 36;
+    let dy = 0;
+    if (y < r.top + M) dy = -Math.ceil((r.top + M - y) / 3);
+    else if (y > r.bottom - M) dy = Math.ceil((y - (r.bottom - M)) / 3);
+    if (dy && scroller.scrollBy) scroller.scrollBy({ top: dy });
+  };
+
+  const beginDrag = () => {
+    cells = getModuleCells();
+    ownIndex = cells.findIndex(c => c.v === variable);
+    if (ownIndex < 0) return false;
+    dragging = true;
+    scroller = cells[ownIndex].div.closest('.lm_content')
+      || document.scrollingElement || document.documentElement;
+    document.body.classList.add('lope-reordering');
+    handle.style.cursor = 'grabbing';
+    // Drop any selection the gesture already started and block new ones for the drag.
+    const sel = window.getSelection && window.getSelection();
+    if (sel && sel.removeAllRanges) sel.removeAllRanges();
+    document.addEventListener('selectstart', blockSelect, true);
+    return true;
+  };
+
+  const onMove = (e) => {
+    if (pointerId == null) return;
+    if (!dragging) {
+      if (Math.abs(e.clientX - startX) < THRESH && Math.abs(e.clientY - startY) < THRESH) return;
+      if (!beginDrag()) return;
+    }
+    e.preventDefault();
+    drawIndicator(gapAt(e.clientY));
+    autoScroll(e.clientY);
+  };
+
+  const teardown = () => {
+    if (pointerId != null && handle.releasePointerCapture) {
+      try { handle.releasePointerCapture(pointerId); } catch (_) {}
+    }
+    handle.removeEventListener('pointermove', onMove);
+    handle.removeEventListener('pointerup', onUp);
+    handle.removeEventListener('pointercancel', onCancel);
+    document.removeEventListener('selectstart', blockSelect, true);
+    handle.style.cursor = '';
+    document.body.classList.remove('lope-reordering');
+    removeIndicator();
+  };
+
+  const onUp = (e) => {
+    const wasDragging = dragging;
+    let target, placeAfter = false, ownDiv = null, doMove = false;
+    if (wasDragging) {
+      ownDiv = cells[ownIndex].div;
+      const g = gapAt(e.clientY);
+      // Drop in own slot (just above or below self) is a no-op.
+      if (g !== ownIndex && g !== ownIndex + 1) {
+        doMove = true;
+        if (g < cells.length) {
+          target = cells[g].v;         // insert before the cell now at the gap
+        } else {
+          target = cells[cells.length - 1].v;  // dropped past the last visible cell
+          placeAfter = true;
+        }
+      }
+    }
+    teardown();
+    pointerId = null; dragging = false; cells = null; ownIndex = -1; scroller = null;
+    if (wasDragging) {
+      // Suppress the click that would otherwise toggle the editor open/closed.
+      const stop = (ev) => { ev.stopPropagation(); ev.preventDefault(); };
+      handle.addEventListener('click', stop, { capture: true, once: true });
+      setTimeout(() => handle.removeEventListener('click', stop, { capture: true }), 0);
+      if (doMove) moveCellBeside(findCell(variable, ownDiv), target, placeAfter);
+    }
+  };
+
+  const onCancel = () => {
+    teardown();
+    pointerId = null; dragging = false; cells = null; ownIndex = -1; scroller = null;
+  };
+
+  const onDown = (e) => {
+    if (e.button != null && e.button !== 0) return;
+    if (e.target && e.target.closest && e.target.closest('.add-cell-btn')) return;
+    pointerId = e.pointerId;
+    startX = e.clientX; startY = e.clientY;
+    dragging = false;
+    if (handle.setPointerCapture) { try { handle.setPointerCapture(e.pointerId); } catch (_) {} }
+    handle.addEventListener('pointermove', onMove);
+    handle.addEventListener('pointerup', onUp);
+    handle.addEventListener('pointercancel', onCancel);
+  };
+
+  handle.addEventListener('pointerdown', onDown);
+  // Suppress the native text-selection drag that would otherwise start on press.
+  // mousedown-preventDefault leaves `click` intact (same trick as the add button).
+  handle.addEventListener('mousedown', e => {
+    if (!(e.target && e.target.closest && e.target.closest('.add-cell-btn'))) e.preventDefault();
+  });
+  handle.addEventListener('selectstart', blockSelect);
+  handle.style.touchAction = 'none';
+  handle.style.userSelect = 'none';
+  return () => handle.removeEventListener('pointerdown', onDown);
+}
+)};
 const _pinoncr = function _pinOnCreate(){return(
 new Set()  // variable pids to open (pin) their editor as soon as the cell mounts
 )};
@@ -792,7 +983,7 @@ const _1rhoxk2 = function _findVariableIndex(runtime){return(
 (variable, variables = runtime._variables) =>
   [...variables].findIndex((vi) => vi === variable)
 )};
-const _2pkmxz = async function _command_processor(command,$0,compile_and_update,remove_variables,$1,findCellIndex,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2,pinOnCreate)
+const _2pkmxz = async function _command_processor(command,$0,compile_and_update,remove_variables,$1,findCellIndex,lookupCellByIndex,findVariableIndex,repositionSetElement,runtime,selectVariable,$2,pinOnCreate,findCell)
 {
     if (command.processed)
         return;
@@ -848,6 +1039,35 @@ const _2pkmxz = async function _command_processor(command,$0,compile_and_update,
                     });
                 }
             }
+        }
+        result = true;
+    } else if (command.command == 'moveCellBeside') {
+        // Drag-drop reorder: place cell's variables immediately before (or, with
+        // placeAfter, after) the anchor cell that `target` belongs to. Repositions by
+        // variable identity, not cell index, so hidden/import/template variables
+        // between visible cells don't skew the destination. The anchor is resolved to
+        // its whole cell so multi-variable cells (viewof/mutable) aren't split, and a
+        // drop past the last visible cell anchors to it (placeAfter) rather than to the
+        // module's far-off last dynamic variable.
+        const { cell, target, placeAfter } = command.args;
+        const anchorCell = findCell(target);
+        const arr = Array.from(runtime._variables);
+        const groupSet = new Set(cell.variables);
+        const group = arr.filter(v => groupSet.has(v));
+        const without = arr.filter(v => !groupSet.has(v));
+        let insertAt = -1;
+        if (anchorCell?.variables?.length) {
+            const idxs = anchorCell.variables
+                .map(v => without.indexOf(v))
+                .filter(i => i >= 0);
+            if (idxs.length)
+                insertAt = placeAfter ? Math.max(...idxs) + 1 : Math.min(...idxs);
+        }
+        if (insertAt >= 0 && group.length) {
+            without.splice(insertAt, 0, ...group);
+            runtime._variables.clear();
+            without.forEach(v => runtime._variables.add(v));
+            await selectVariable(cell.variables[0], cell.dom);
         }
         result = true;
     }
@@ -1880,7 +2100,7 @@ export default function define(runtime, observer) {
   $def("_1oaz8r1", "attachContextManu", ["Generators","viewof attachContextManu"], _1oaz8r1);  
   $def("_16ks4jz", null, ["md"], _16ks4jz);  
   $def("_199ztvl", "hotbarTemplate", ["lookupVariable","editorModule"], _199ztvl);  
-  $def("_1q95xt6", "cellEditor", ["cloneDataflow","editorTemplate","shellTemplate","getOption","Event","setOption","createCell","findCell","pinOnCreate"], _1q95xt6);
+  $def("_1q95xt6", "cellEditor", ["cloneDataflow","editorTemplate","shellTemplate","getOption","Event","setOption","createCell","findCell","pinOnCreate","dragReorder"], _1q95xt6);
   $def("_x5ixji", "hotbar_shell", ["viewof edit","Event","htl","edit"], _x5ixji);  
   $def("_1ed5zb9", "editor_panel", ["viewof editedCell","htl","toolbar","nav","reversibleAttach","combine","code_editor"], _1ed5zb9);  
   $def("_yk7udl", "shellTemplate", ["viewof editedCell","editedCell","selectVariable","viewof edit","edit","hotbar_shell","lookupVariable","editorModule"], _yk7udl);  
@@ -1924,7 +2144,9 @@ export default function define(runtime, observer) {
   $def("_rv7t7x", "code_editor_view", ["EditorView"], _rv7t7x);  
   $def("_xvo1n6", "code_editor", ["code_editor_view"], _xvo1n6);  
   $def("_1imarq2", null, ["md"], _1imarq2);  
-  $def("_470wv4", "moveCell", ["viewof command"], _470wv4);  
+  $def("_470wv4", "moveCell", ["viewof command"], _470wv4);
+  $def("_mvbs01", "moveCellBeside", ["viewof command"], _mvbs01);
+  $def("_drag01", "dragReorder", ["runtime","divToVar","findCell","moveCellBeside"], _drag01);  
   $def("_pinoncr", "pinOnCreate", [], _pinoncr);
   $def("_19znal9", "createCell", ["viewof command"], _19znal9);
   $def("_d9nzys", "deleteCell", ["viewof command"], _d9nzys);  
@@ -1936,7 +2158,7 @@ export default function define(runtime, observer) {
   $def("_dmk8lv", "findCellIndex", [], _dmk8lv);  
   $def("_jy01vb", "lookupCellByIndex", [], _jy01vb);  
   $def("_1rhoxk2", "findVariableIndex", ["runtime"], _1rhoxk2);  
-  $def("_2pkmxz", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","viewof liveCellMap","findCellIndex","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command","pinOnCreate"], _2pkmxz);  
+  $def("_2pkmxz", "command_processor", ["command","viewof edit","compile_and_update","remove_variables","viewof liveCellMap","findCellIndex","lookupCellByIndex","findVariableIndex","repositionSetElement","runtime","selectVariable","viewof command","pinOnCreate","findCell"], _2pkmxz);  
   $def("_8iz5z2", null, ["md"], _8iz5z2);  
   $def("_m873d1", "states", [], _m873d1);  
   $def("_mxwoc4", "cellIdFacet", ["codemirror"], _mxwoc4);  


### PR DESCRIPTION
Drag a cell's **hotbar** (the always-present shell bar, before the heavy editor opens) to reposition it — an alternative to the ⬆⬇ arrows buried inside the opened editor.

The bar reads `⠿ ⋯ ➕ edit`. The `⠿` grip (floated left) is the affordance; the **whole bar** is the drag handle.

## Behaviour
- Pointer drag with a 5px threshold, a drop-line indicator, and edge auto-scroll.
- A plain **click still toggles the editor**; a real drag suppresses the trailing click.
- Native text selection is suppressed for the gesture: `mousedown` preventDefault (leaves `click` intact — same trick the `➕` button uses) plus a `selectstart` blocker installed for the drag and removed on drop.

## Why not reuse `moveCell(cell, amount)`
Two reasons an index-based relative move is wrong here:

1. `liveCellMap`'s cell list is **not 1:1** with the visible `.observablehq` divs — it includes hidden import/`@variable` cells. An index computed from visible positions is wrong whenever a hidden cell sits between two visible ones.
2. This module spawns **thousands of dynamic template variables** (every cell gets a `cellEditor` clone), so the module's *last variable* sits thousands of slots past the *last visible cell*. Appending "to module end" lands nowhere useful — observed at index ~4070 vs a last visible cell at ~503.

`moveCellBeside(cell, target, placeAfter)` instead repositions by **variable identity**: it resolves the drop target to its whole cell via `findCell`, then splices the dragged group before (min index) / after (max index) that cell's variables. So multi-variable `viewof`/`mutable` cells are never split, and a drop past the last visible cell anchors to *that* cell rather than the hidden tail.

## `moveCell` is kept, deliberately
The two are complementary, not redundant. `moveCell`'s relative nudge + scroll-pinning (#163 — matters when a cell embeds a 500px iframe and a one-step move would jump the viewport) is right for the arrow buttons. Drag deliberately leaves the cell where you dropped it, so it skips that compensation. Nothing outside editor-5 imports `moveCell`.

## New cells
- `dragReorder(variable, handle)` — all drag logic, wired into `cellEditor`'s shell mount
- `moveCellBeside(cell, target, placeAfter)` — API + `command_processor` branch
- `command_processor` gains a `findCell` dependency

## Verification
Driven live through the pairing channel with synthetic pointer events:
- **up**, **down** and **bottom-drop** all land correctly — asserted on *visible DOM order*, not raw variable indices (multi-var cells and hidden vars make index deltas misleading)
- click-to-open still works (host 17px → 2970px); drag suppresses the click
- seeded a 27-char selection → cleared to 0 on drag start, new selections blocked during, listener removed after
- no leftover `lope-reordering` class, stray indicators, or orphaned editor hosts

## Scope
Module source only. The synced notebook (`lopebooks/notebooks/@tomlarkworthy_editor-5.html`) is regenerable via `sync-module.ts` and is intentionally **not** included. Not yet pushed to ObservableHQ, and not yet fanned out to the ~216 consumer notebooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)