### PR TITLE
Module store + submodule: toolchain and exporter-3 without escodegen

### DIFF
--- a/modules/@tomlarkworthy/exporter-3.js
+++ b/modules/@tomlarkworthy/exporter-3.js
@@ -4,12 +4,12 @@ md`# Exporter 3
 ## [video explainer for exporter 2](https://www.youtube.com/watch?v=wx93r1pY_6Y)
 `
 )};
-const _1xs1o58 = function _2(exporter,$0,Event){return(
+const _vpmotg = function _2(exporter,$0,Event){return(
 exporter({
-    output: out => {
-        $0.value = out;
-        $0.dispatchEvent(new Event('input'));
-    }
+  output: out => {
+    $0.value = out;
+    $0.dispatchEvent(new Event('input'));
+  }
 })
 )};
 const _16yvadj = function _3(md,downloadAnchor,forkAnchor){return(
@@ -109,8 +109,9 @@ fill => html`<svg ${ fill ? `fill="${ fill }" ` : '' }width="50px" height="50px"
 const _ibwdcx = function _11(md){return(
 md`## Implementation`
 )};
-const _4vze8h = function _exporter(actionHandler,css,keepalive,exporter_module,variable,domView,view,disk_svg,Inputs,themes,$0,linkTo){return(
-({handler = actionHandler, style = css, output = out => {
+const _1p4bp3o = function _exporter(actionHandler,css,keepalive,exporter_module,variable,domView,view,disk_svg,linkTo,Inputs,themes,$0)
+{
+  return ({handler = actionHandler, style = css, output = out => {
     }, debug = false} = {}) => {
     keepalive(exporter_module, 'futureExportedState');
     const handlerVar = variable(handler);
@@ -118,24 +119,25 @@ const _4vze8h = function _exporter(actionHandler,css,keepalive,exporter_module,v
     // prerender defaults ON; only an explicit "prerender": false in bootconf turns it off
     let prerenderDefault = true;
     try {
-        const conf = JSON.parse(new window.TextDecoder().decode(window.lopecode.contentSync('bootconf.json').bytes));
-        if (conf.prerender === false) prerenderDefault = false;
+      const conf = JSON.parse(new window.TextDecoder().decode(window.lopecode.contentSync('bootconf.json').bytes));
+      if (conf.prerender === false)
+        prerenderDefault = false;
     } catch (e) {
     }
     const options = {
-        style,
-        output,
-        debug
+      style,
+      output,
+      debug
     };
     const spinner = async (...args) => {
-        try {
-            ui.querySelector('.disk-image').classList.add('spinning');
-            await handler(...args, cb => feedback.value = cb);
-            ui.querySelector('.disk-image').classList.remove('spinning');
-        } catch (e) {
-            ui.querySelector('.disk-image').classList.remove('spinning');
-            throw e;
-        }
+      try {
+        ui.querySelector('.disk-image').classList.add('spinning');
+        await handler(...args, cb => feedback.value = cb);
+        ui.querySelector('.disk-image').classList.remove('spinning');
+      } catch (e) {
+        ui.querySelector('.disk-image').classList.remove('spinning');
+        throw e;
+      }
     };
     const ui = view`<div class="moldbook-exporter" style="max-width: 440px;">
     <style>
@@ -194,8 +196,8 @@ const _4vze8h = function _exporter(actionHandler,css,keepalive,exporter_module,v
       }
     </style>
     ${ [
-        'handler',
-        handlerVar
+      'handler',
+      handlerVar
     ] }
     <div style="display: flex; align-items: flex-start; gap: 8px;">
       <div class="disk-image">${ disk_svg() }</div>
@@ -208,31 +210,38 @@ const _4vze8h = function _exporter(actionHandler,css,keepalive,exporter_module,v
           </summary>
           <div class="moldbook-advanced-body">
             ${ [
-        'prerender',
-        Inputs.toggle({ label: 'prerender', value: prerenderDefault })
+      'prerender',
+      Inputs.toggle({
+        label: 'prerender',
+        value: prerenderDefault
+      })
     ] }
             ${ [
-        'theme',
-        Inputs.bind(Inputs.select(themes, { label: 'theme' }), $0)
+      'theme',
+      Inputs.bind(Inputs.select(themes, { label: 'theme' }), $0)
     ] }
             ${ [
-        'bootloader',
-        Inputs.text({ label: 'bootloader', value: '@tomlarkworthy/bootloader', placeholder: '@tomlarkworthy/bootloader' })
+      'bootloader',
+      Inputs.text({
+        label: 'bootloader',
+        value: '@tomlarkworthy/bootloader',
+        placeholder: '@tomlarkworthy/bootloader'
+      })
     ] }
           </div>
         </details>
         <div style="display: flex; gap: 5px; flex-wrap: wrap;">
           ${ [
-        'copyjs',
-        Inputs.button('Copy as JS', { reduce: () => spinner('copyjs', ui.value, options) })
+      'copyjs',
+      Inputs.button('Copy as JS', { reduce: () => spinner('copyjs', ui.value, options) })
     ] }
           ${ [
-        'blob',
-        Inputs.button('Fork', { reduce: () => spinner('tab', ui.value, options) })
+      'blob',
+      Inputs.button('Fork', { reduce: () => spinner('tab', ui.value, options) })
     ] }
           ${ [
-        'html',
-        Inputs.button('Download', { reduce: () => spinner('file', ui.value, options) })
+      'html',
+      Inputs.button('Download', { reduce: () => spinner('file', ui.value, options) })
     ] }
         </div>
       </div>
@@ -242,35 +251,35 @@ const _4vze8h = function _exporter(actionHandler,css,keepalive,exporter_module,v
     // keep the "fork notebook" link navigable without toggling the <details>
     ui.querySelector('.moldbook-target')?.addEventListener('click', e => e.stopPropagation());
     return ui;
-}
-)};
-const _5xp8ad = function _copyTextToClipboard(globalThis){return(
+  };
+};
+const _14mjs7h = function _copyTextToClipboard(globalThis){return(
 async text => {
-    text = String(text ?? '');
-    if (globalThis.navigator?.clipboard?.writeText) {
-        await navigator.clipboard.writeText(text);
-        return true;
-    }
-    const ta = document.createElement('textarea');
-    ta.value = text;
-    ta.setAttribute('readonly', '');
-    ta.style.position = 'fixed';
-    ta.style.left = '-9999px';
-    ta.style.top = '0';
-    document.body.appendChild(ta);
-    ta.select();
-    const ok = document.execCommand('copy');
-    ta.remove();
-    if (!ok)
-        throw new Error('Clipboard copy failed (no navigator.clipboard and execCommand failed)');
+  text = String(text ?? '');
+  if (globalThis.navigator?.clipboard?.writeText) {
+    await navigator.clipboard.writeText(text);
     return true;
+  }
+  const ta = document.createElement('textarea');
+  ta.value = text;
+  ta.setAttribute('readonly', '');
+  ta.style.position = 'fixed';
+  ta.style.left = '-9999px';
+  ta.style.top = '0';
+  document.body.appendChild(ta);
+  ta.select();
+  const ok = document.execCommand('copy');
+  ta.remove();
+  if (!ok)
+    throw new Error('Clipboard copy failed (no navigator.clipboard and execCommand failed)');
+  return true;
 }
 )};
-const _ywlem4 = function _htmlToConsoleSnippet(utf8ToBase64){return(
+const _1sbph8c = function _htmlToConsoleSnippet(utf8ToBase64){return(
 (html, {title = 'Observable notebook', zIndex = 2147483647} = {}) => {
-    const b64 = utf8ToBase64(html);
-    const safeTitle = String(title).replace(/`/g, '\\`');
-    return `(async () => {
+  const b64 = utf8ToBase64(html);
+  const safeTitle = String(title).replace(/`/g, '\\`');
+  return `(async () => {
   const b64 = "${ b64 }";
   const bytes = Uint8Array.from(atob(b64), c => c.charCodeAt(0));
   const html = new TextDecoder().decode(bytes);
@@ -355,103 +364,103 @@ const _ywlem4 = function _htmlToConsoleSnippet(utf8ToBase64){return(
 })();`;
 }
 )};
-const _1gdtxyo = function _exportAnchor(Node,notebook_name,main,_runtime,exportToHTML,location,getCompactISODate){return(
+const _1w6fc3k = function _exportAnchor(Node,notebook_name,main,_runtime,exportToHTML,location,getCompactISODate){return(
 (action, attrs = {}, label = action, exportOpts = {}) => {
-    const a = document.createElement('a');
-    const {href = '#', title, className, style, target, rel, ...rest} = attrs ?? {};
-    a.href = href;
-    if (title != null)
-        a.title = title;
-    if (className != null)
-        a.className = className;
-    if (style != null)
-        a.setAttribute('style', style);
-    if (target != null)
-        a.target = target;
-    if (rel != null)
-        a.rel = rel;
-    for (const [k, v] of Object.entries(rest)) {
-        if (v == null)
-            continue;
-        if (k.startsWith('on') && typeof v === 'function')
-            continue;
-        try {
-            a.setAttribute(k, String(v));
-        } catch {
-        }
+  const a = document.createElement('a');
+  const {href = '#', title, className, style, target, rel, ...rest} = attrs ?? {};
+  a.href = href;
+  if (title != null)
+    a.title = title;
+  if (className != null)
+    a.className = className;
+  if (style != null)
+    a.setAttribute('style', style);
+  if (target != null)
+    a.target = target;
+  if (rel != null)
+    a.rel = rel;
+  for (const [k, v] of Object.entries(rest)) {
+    if (v == null)
+      continue;
+    if (k.startsWith('on') && typeof v === 'function')
+      continue;
+    try {
+      a.setAttribute(k, String(v));
+    } catch {
     }
-    if (label instanceof Node)
-        a.appendChild(label);
-    else
-        a.textContent = label == null ? '' : String(label);
-    const clickHandler = async event => {
-        event.preventDefault();
-        event.stopPropagation();
-        if (a.dataset.busy === '1')
-            return;
-        a.dataset.busy = '1';
-        const prevAriaBusy = a.getAttribute('aria-busy');
-        a.setAttribute('aria-busy', 'true');
-        const prevPointerEvents = a.style.pointerEvents;
-        const prevOpacity = a.style.opacity;
-        a.style.pointerEvents = 'none';
-        a.style.opacity = '0.6';
-        let blobUrl = null;
-        try {
-            const mains = exportOpts.mains ?? (notebook_name ? new Map([[
-                    notebook_name,
-                    main
-                ]]) : _runtime.mains);
-            const runtime = exportOpts.runtime ?? _runtime;
-            const title = exportOpts.title ?? [...mains.keys()][0] ?? 'notebook';
-            const bootloader = exportOpts.bootloader ?? '@tomlarkworthy/bootloader';
-            const appendHash = exportOpts.appendHash ?? true;
-            const resp = await exportToHTML({
-                mains,
-                runtime,
-                options: {
-                    title,
-                    bootloader,
-                    ...exportOpts.options ?? {},
-                    ...exportOpts.theme != null ? { theme: exportOpts.theme } : null,
-                    ...exportOpts.style != null ? { style: exportOpts.style } : null,
-                    ...exportOpts.head != null ? { head: exportOpts.head } : null,
-                    ...exportOpts.headless != null ? { headless: exportOpts.headless } : null,
-                    ...exportOpts.hash != null ? { hash: exportOpts.hash } : null
-                }
-            });
-            const html = resp?.source ?? resp;
-            blobUrl = URL.createObjectURL(new Blob([html], { type: 'text/html' }));
-            if (action === 'tab' || action === 'fork') {
-                const hash = exportOpts.hash ?? location.hash ?? '';
-                window.open(blobUrl + (appendHash ? hash : ''), '_blank');
-                setTimeout(() => URL.revokeObjectURL(blobUrl), 60000);
-            } else if (action === 'download' || action === 'file') {
-                const filename = exportOpts.filename ?? `${ title }_${ getCompactISODate() }.html`;
-                const dl = document.createElement('a');
-                dl.href = blobUrl;
-                dl.download = filename;
-                dl.click();
-                setTimeout(() => URL.revokeObjectURL(blobUrl), 5000);
-            } else {
-                throw new Error(`Unknown export action: ${ action }`);
-            }
-        } finally {
-            a.dataset.busy = '0';
-            if (prevAriaBusy == null)
-                a.removeAttribute('aria-busy');
-            else
-                a.setAttribute('aria-busy', prevAriaBusy);
-            a.style.pointerEvents = prevPointerEvents;
-            a.style.opacity = prevOpacity;
+  }
+  if (label instanceof Node)
+    a.appendChild(label);
+  else
+    a.textContent = label == null ? '' : String(label);
+  const clickHandler = async event => {
+    event.preventDefault();
+    event.stopPropagation();
+    if (a.dataset.busy === '1')
+      return;
+    a.dataset.busy = '1';
+    const prevAriaBusy = a.getAttribute('aria-busy');
+    a.setAttribute('aria-busy', 'true');
+    const prevPointerEvents = a.style.pointerEvents;
+    const prevOpacity = a.style.opacity;
+    a.style.pointerEvents = 'none';
+    a.style.opacity = '0.6';
+    let blobUrl = null;
+    try {
+      const mains = exportOpts.mains ?? (notebook_name ? new Map([[
+          notebook_name,
+          main
+        ]]) : _runtime.mains);
+      const runtime = exportOpts.runtime ?? _runtime;
+      const title = exportOpts.title ?? [...mains.keys()][0] ?? 'notebook';
+      const bootloader = exportOpts.bootloader ?? '@tomlarkworthy/bootloader';
+      const appendHash = exportOpts.appendHash ?? true;
+      const resp = await exportToHTML({
+        mains,
+        runtime,
+        options: {
+          title,
+          bootloader,
+          ...exportOpts.options ?? {},
+          ...exportOpts.theme != null ? { theme: exportOpts.theme } : null,
+          ...exportOpts.style != null ? { style: exportOpts.style } : null,
+          ...exportOpts.head != null ? { head: exportOpts.head } : null,
+          ...exportOpts.headless != null ? { headless: exportOpts.headless } : null,
+          ...exportOpts.hash != null ? { hash: exportOpts.hash } : null
         }
-    };
-    a.addEventListener('click', clickHandler);
-    if (typeof attrs?.onclick === 'function') {
-        const userHandler = attrs.onclick;
-        a.addEventListener('click', e => userHandler(e));
+      });
+      const html = resp?.source ?? resp;
+      blobUrl = URL.createObjectURL(new Blob([html], { type: 'text/html' }));
+      if (action === 'tab' || action === 'fork') {
+        const hash = exportOpts.hash ?? location.hash ?? '';
+        window.open(blobUrl + (appendHash ? hash : ''), '_blank');
+        setTimeout(() => URL.revokeObjectURL(blobUrl), 60000);
+      } else if (action === 'download' || action === 'file') {
+        const filename = exportOpts.filename ?? `${ title }_${ getCompactISODate() }.html`;
+        const dl = document.createElement('a');
+        dl.href = blobUrl;
+        dl.download = filename;
+        dl.click();
+        setTimeout(() => URL.revokeObjectURL(blobUrl), 5000);
+      } else {
+        throw new Error(`Unknown export action: ${ action }`);
+      }
+    } finally {
+      a.dataset.busy = '0';
+      if (prevAriaBusy == null)
+        a.removeAttribute('aria-busy');
+      else
+        a.setAttribute('aria-busy', prevAriaBusy);
+      a.style.pointerEvents = prevPointerEvents;
+      a.style.opacity = prevOpacity;
     }
-    return a;
+  };
+  a.addEventListener('click', clickHandler);
+  if (typeof attrs?.onclick === 'function') {
+    const userHandler = attrs.onclick;
+    a.addEventListener('click', e => userHandler(e));
+  }
+  return a;
 }
 )};
 const _1u2ju69 = function _forkAnchor(exportAnchor){return(
@@ -460,88 +469,90 @@ const _1u2ju69 = function _forkAnchor(exportAnchor){return(
 const _1a8n42w = function _downloadAnchor(exportAnchor){return(
 (attrs = {}, label = 'download', exportOpts = {}) => exportAnchor('download', attrs, label, exportOpts)
 )};
-const _r3bep4 = function _actionHandler(Inputs,getSourceModule,notebook_name,_runtime,exportToHTML,htmlToConsoleSnippet,copyTextToClipboard,view,location,getCompactISODate,linkTo){return(
-async (action, state, options, feedback_callback) => {
+const _4zsqot = function _actionHandler(Inputs,getSourceModule,notebook_name,_runtime,exportToHTML,htmlToConsoleSnippet,copyTextToClipboard,view,linkTo,location,getCompactISODate)
+{
+  return async (action, state, options, feedback_callback) => {
     feedback_callback(Inputs.textarea({ value: `Generating source...\n` }));
     const {notebook, module, runtime} = await getSourceModule(state);
     const mains = notebook_name ? new Map([[
-            notebook,
-            module
-        ]]) : _runtime.mains;
+        notebook,
+        module
+      ]]) : _runtime.mains;
     let title = [...mains.keys()][0];
     try {
-        const r = window.lopecode.contentSync('bootconf.json');
-        const b = JSON.parse(new window.TextDecoder().decode(r.bytes)).mains[0];
-        if (!notebook_name && mains.has(b)) title = b;
-    } catch (e) {}
+      const r = window.lopecode.contentSync('bootconf.json');
+      const b = JSON.parse(new window.TextDecoder().decode(r.bytes)).mains[0];
+      if (!notebook_name && mains.has(b))
+        title = b;
+    } catch (e) {
+    }
     const response = await exportToHTML({
-        mains,
-        runtime,
-        options: {
-            bootloader: state.bootloader,
-            title,
-            ...state.prerender != null ? { prerender: state.prerender } : null,
-            ...options
-        }
+      mains,
+      runtime,
+      options: {
+        bootloader: state.bootloader,
+        title,
+        ...state.prerender != null ? { prerender: state.prerender } : null,
+        ...options
+      }
     });
     if (options.output)
-        options.output(response);
+      options.output(response);
     const {source, report} = response;
     if (action === 'copyjs') {
-        const snippet = htmlToConsoleSnippet(source, { title });
-        await copyTextToClipboard(snippet);
-        feedback_callback(view`<div style="padding: 8px;">
+      const snippet = htmlToConsoleSnippet(source, { title });
+      await copyTextToClipboard(snippet);
+      feedback_callback(view`<div style="padding: 8px;">
       <div><b>Copied</b> JS snippet to clipboard.</div>
       <div style="opacity: 0.75; font-size: 12px;">Paste into a JS console to inject the notebook as a full-screen overlay.</div>
     </div>`);
-        return;
+      return;
     }
     const url = URL.createObjectURL(new Blob([source], { type: 'text/html' }));
     // The report table doubles as a table of contents: the notebook's own openable
     // modules (@user/module, not versioned npm deps or the observablehq namespace)
     // render their `id` as a link that opens that module in the live layout via the
     // lopepage "open" intent; everything else stays plain text.
-    const isOpenableModule = id => typeof id === 'string'
-        && /^@[^@/\s]+\/[^@/\s]+$/.test(id)
-        && !id.startsWith('@observablehq/');
+    const isOpenableModule = id => typeof id === 'string' && /^@[^@/\s]+\/[^@/\s]+$/.test(id) && !id.startsWith('@observablehq/');
     feedback_callback(view`
     <center><a href="${ url }" target="_blank">export</a></center>
     ${ Inputs.table(report.filter(f => !f.file), {
-        columns: [
-            'id',
-            'size'
-        ],
-        width: {
-            id: '80%',
-            size: '20%'
-        },
-        format: {
-            id: id => {
-                if (!isOpenableModule(id)) return id;
-                const a = document.createElement('a');
-                a.textContent = id;
-                a.href = linkTo({ open: id });
-                a.style.color = 'var(--theme-foreground-focus)';
-                return a;
-            }
-        },
-        sort: 'size',
-        reverse: true
+      columns: [
+        'id',
+        'size'
+      ],
+      width: {
+        id: '80%',
+        size: '20%'
+      },
+      format: {
+        id: id => {
+          if (!isOpenableModule(id))
+            return id;
+          const a = document.createElement('a');
+          a.textContent = id;
+          a.href = linkTo({ open: id });
+          a.style.color = 'var(--theme-foreground-focus)';
+          return a;
+        }
+      },
+      sort: 'size',
+      reverse: true
     }) }
   `);
     if (action === 'tab') {
-        window.open(url + location.hash, '_blank');
+      window.open(url + location.hash, '_blank');
     } else if (action === 'file') {
-        const a = document.createElement('a');
-        a.href = url;
-        a.download = `${ title }_${ getCompactISODate() }.html`;
-        a.click();
-        URL.revokeObjectURL(url);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `${ title }_${ getCompactISODate() }.html`;
+      a.click();
+      URL.revokeObjectURL(url);
     }
-}
-)};
-const _k7go5d = function _exportToHTML(_runtime, cssForTheme, css, location, keepalive, exporter_module, $0) {
-    return async function exportToHTML({mains = new Map(), runtime = _runtime, options = {}} = {}) {
+  };
+};
+const _lb3gzc = function _exportToHTML(_runtime,cssForTheme,css,location,keepalive,exporter_module,$0){return(
+async function exportToHTML({mains = new Map(), runtime = _runtime, options = {}} = {}) {
         let conf = { headless: false };
         try {
             conf = (await import('file://bootconf.json')).default;
@@ -562,9 +573,10 @@ const _k7go5d = function _exportToHTML(_runtime, cssForTheme, css, location, kee
         if (options.tickDelayMs == null) {
             options.tickDelayMs = conf.tickDelayMs;
         }
-        // Prerender flag persists in bootconf.json across re-exports (like headless/tick).
+        // Prerender defaults ON (matching the exporter UI toggle); only an explicit
+        // "prerender": false in bootconf.json turns it off. Flag persists across re-exports.
         if (options.prerender == null) {
-            options.prerender = conf.prerender;
+            options.prerender = conf.prerender !== false;
         }
         // Snapshot the live lopepage-2 DOM (only when exporting this running notebook).
         // The snapshot keeps its id="lopepage-2" and scoped styles unchanged; book() nests
@@ -628,213 +640,214 @@ const _k7go5d = function _exportToHTML(_runtime, cssForTheme, css, location, kee
             options
         });
         return response;
-    };
-};
-const _17k9v19 = function _getSourceModule(notebook_name, main, _runtime, importShim) {
-    return async state => {
-        // source picker was removed; the exporter always serialises this notebook
-        if (!state.source || state.source == 'this notebook')
-            return {
-                notebook: notebook_name,
-                module: main,
-                runtime: _runtime
-            };
-        const url = state.source == 'a notebook url' ? state.notebook_url.child : state.top_100.child;
-        const notebook = url.trim().replace('', '');
-        const [{Runtime, Inspector}, {default: define}] = await Promise.all([
-            import('https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js'),
-            import(`https://api.observablehq.com/${ notebook }.js?v=4`)
-        ]);
-        const runtime = new Runtime();
-        return {
-            notebook,
-            module: runtime.module(define),
-            runtime
-        };
-    };
-};
-const _6vlf2p = function _createShowable(variable,view)
+    }
+)};
+const _43zr7 = function _getSourceModule(notebook_name,main,_runtime)
 {
-    return function createShowable(child, {
-        show = true
-    } = {}) {
-        const showVariable = variable(show, { name: 'show' });
-        const showable = view`<div>${ [
-            'show',
-            showVariable
-        ] }${ [
-            'child',
-            child
-        ] }`;
-        // The showable logic is to toggle the visibility of the enclosing div based
-        // on the show variable state
-        const updateDisplay = () => {
-            if (showVariable.value) {
-                showable.style.display = 'inline';
-            } else {
-                showable.style.display = 'none';
-            }
-        };
-        // Variables have additional assign event so presentation can be
-        // updated as soon as variables change but before dataflow
-        // because this is a pure presentation state it makes sense not to trigger
-        // dataflow so we do not use 'input' event
-        showVariable.addEventListener('assign', updateDisplay);
-        updateDisplay();
-        return showable;
+  return async state => {
+    // source picker was removed; the exporter always serialises this notebook
+    if (!state.source || state.source == 'this notebook')
+      return {
+        notebook: notebook_name,
+        module: main,
+        runtime: _runtime
+      };
+    const url = state.source == 'a notebook url' ? state.notebook_url.child : state.top_100.child;
+    const notebook = url.trim().replace('', '');
+    const [{Runtime, Inspector}, {default: define}] = await Promise.all([
+      import('https://cdn.jsdelivr.net/npm/@observablehq/runtime@4/dist/runtime.js'),
+      import(`https://api.observablehq.com/${ notebook }.js?v=4`)
+    ]);
+    const runtime = new Runtime();
+    return {
+      notebook,
+      module: runtime.module(define),
+      runtime
     };
+  };
 };
-const _zclcql = function _reportValidity(){return(
+const _tpv4tl = function _createShowable(variable,view)
+{
+  return function createShowable(child, {
+    show = true
+  } = {}) {
+    const showVariable = variable(show, { name: 'show' });
+    const showable = view`<div>${ [
+      'show',
+      showVariable
+    ] }${ [
+      'child',
+      child
+    ] }`;
+    // The showable logic is to toggle the visibility of the enclosing div based
+    // on the show variable state
+    const updateDisplay = () => {
+      if (showVariable.value) {
+        showable.style.display = 'inline';
+      } else {
+        showable.style.display = 'none';
+      }
+    };
+    // Variables have additional assign event so presentation can be
+    // updated as soon as variables change but before dataflow
+    // because this is a pure presentation state it makes sense not to trigger
+    // dataflow so we do not use 'input' event
+    showVariable.addEventListener('assign', updateDisplay);
+    updateDisplay();
+    return showable;
+  };
+};
+const _rnq9mt = function _reportValidity(){return(
 (view, invalidation) => {
-    const input = view.querySelector('input');
-    const report = () => view.reportValidity();
-    input.addEventListener('input', report);
-    invalidation.then(() => input.removeEventListener('input', report));
-    return view;
+  const input = view.querySelector('input');
+  const report = () => view.reportValidity();
+  input.addEventListener('input', report);
+  invalidation.then(() => input.removeEventListener('input', report));
+  return view;
 }
 )};
-const _10rnvxz = function _top120List(){return(
+const _3vwqe7 = function _top120List(){return(
 [
-    '@jashkenas/inputs',
-    '@d3/gallery',
-    '@d3/learn-d3',
-    '@makio135/creative-coding',
-    '@observablehq/module-require-debugger',
-    '@d3/zoomable-sunburst',
-    '@observablehq/plot',
-    '@tmcw/enigma-machine',
-    '@d3/force-directed-graph-component',
-    '@d3/bar-chart-race-explained',
-    '@observablehq/data-wrangler',
-    '@d3/collapsible-tree',
-    '@sxywu/introduction-to-svg-and-d3-js',
-    '@d3/sankey-component',
-    '@d3/zoomable-circle-packing',
-    '@d3/selection-join',
-    '@bstaats/graph-visualization-introduction',
-    '@d3/color-legend',
-    '@uwdata/introducing-arquero',
-    '@mbostock/10-years-of-open-source-visualization',
-    '@nitaku/tangled-tree-visualization-ii',
-    '@makio135/give-me-colors',
-    '@johnburnmurdoch/bar-chart-race-the-most-populous-cities-in-the-world',
-    '@d3/color-schemes',
-    '@tezzutezzu/world-history-timeline',
-    '@d3/calendar',
-    '@observablehq/a-taste-of-observable',
-    '@d3/bar-chart-race',
-    '@mourner/martin-real-time-rtin-terrain-mesh',
-    '@uwdata/introduction-to-vega-lite',
-    '@mbostock/voronoi-stippling',
-    '@ben-tanen/a-tutorial-to-using-d3-force-from-someone-who-just-learned-ho',
-    '@d3/hierarchical-edge-bundling',
-    '@observablehq/introduction-to-data',
-    '@harrystevens/directly-labelling-lines',
-    '@observablehq/summary-table',
-    '@observablehq/plot-cheatsheets',
-    '@tomshanley/cheysson-color-palettes',
-    '@tophtucker/inferring-chart-type-from-autocorrelation-and-other-evils',
-    '@mitvis/introduction-to-d3',
-    '@veltman/watercolor',
-    '@veltman/centerline-labeling',
-    '@mbostock/scrubber',
-    '@observablehq/electoral-college-decision-tree',
-    '@d3/tree-component',
-    '@d3/radial-tree-component',
-    '@d3/world-tour',
-    '@observablehq/introduction-to-generators',
-    '@yurivish/peak-detection',
-    '@mkfreeman/plot-tooltip',
-    '@aboutaaron/racial-demographic-dot-density-map',
-    '@mbostock/methods-of-comparison-compared',
-    '@rreusser/gpgpu-boids',
-    '@rreusser/2d-n-body-gravity-with-poissons-equation',
-    '@bumbeishvili/data-driven-range-sliders',
-    '@observablehq/introducing-visual-dataflow',
-    '@observablehq/vega-lite',
-    '@observablehq/observable-for-jupyter-users',
-    '@observablehq/how-observable-runs',
-    '@unkleho/introducing-d3-render-truly-declarative-and-reusable-d3',
-    '@vega/a-guide-to-guides-axes-legends-in-vega',
-    '@bartok32/diy-inputs',
-    '@mbostock/polar-clock',
-    '@dakoop/learn-js-data',
-    '@mbostock/manipulating-flat-arrays',
-    '@uwdata/an-illustrated-guide-to-arquero-verbs',
-    '@daformat/rounding-polygon-corners',
-    '@yurivish/seasonal-spirals',
-    '@emamd/animating-lots-and-lots-of-circles-with-regl-js',
-    '@uwdata/data-visualization-curriculum',
-    '@d3/d3-group',
-    '@d3/tree-of-life',
-    '@d3/arc-diagram',
-    '@d3/choropleth',
-    '@mattdzugan/generative-art-using-wind-turbine-data',
-    '@jashkenas/handy-embed-code-generator',
-    '@analyzer2004/plot-gallery',
-    '@nsthorat/how-to-build-a-teachable-machine-with-tensorflow-js',
-    '@d3/sunburst-component',
-    '@tomlarkworthy/saas-tutorial',
-    '@mbostock/the-wealth-health-of-nations',
-    '@yy/covid-19-fatality-rate',
-    '@bryangingechen/importing-data-from-google-spreadsheets-into-a-notebook-we',
-    '@mbostock/slide',
-    '@kerryrodden/sequences-sunburst',
-    '@d3/zoom-to-bounding-box',
-    '@ambassadors/interactive-plot-dashboard',
-    '@sethpipho/fractal-tree',
-    '@mbostock/saving-svg',
-    '@analyzer2004/west-coast-weather-from-seattle-to-san-diego',
-    '@tmcw/tables',
-    '@observablehq/introduction-to-serverless-notebooks',
-    '@mootari/range-slider',
-    '@d3/animated-treemap',
-    '@d3/treemap-component',
-    '@uwdata/interaction',
-    '@hydrosquall/d3-annotation-with-d3-line-chart',
-    '@jiazhewang/introduction-to-antv',
-    '@d3/hierarchical-bar-chart',
-    '@uwdata/data-types-graphical-marks-and-visual-encoding-channels',
-    '@observablehq/why-use-a-radial-data-visualization',
-    '@kerryrodden/introduction-to-text-analysis-with-tf-idf',
-    '@uw-info474/javascript-data-wrangling',
-    '@karimdouieb/try-to-impeach-this-challenge-accepted',
-    '@observablehq/plot-gallery',
-    '@carmen-tm/women-architects-i-didnt-hear-about',
-    '@d3/versor-dragging',
-    '@analyzer2004/timespiral',
-    '@d3/brushable-scatterplot-matrix',
-    '@observablehq/require',
-    '@anjana/functional-javascript-first-steps',
-    '@hamzaamjad/tiny-charts',
-    '@observablehq/views',
-    '@yurivish/quarantine-now',
-    '@analyzer2004/performance-chart',
-    '@freedmand/sounds',
-    '@d3/bubble-chart-component',
-    '@d3/mobile-patent-suits',
-    '@observablehq/notebook-visualizer',
-    '@d3/force-directed-tree'
+  '@jashkenas/inputs',
+  '@d3/gallery',
+  '@d3/learn-d3',
+  '@makio135/creative-coding',
+  '@observablehq/module-require-debugger',
+  '@d3/zoomable-sunburst',
+  '@observablehq/plot',
+  '@tmcw/enigma-machine',
+  '@d3/force-directed-graph-component',
+  '@d3/bar-chart-race-explained',
+  '@observablehq/data-wrangler',
+  '@d3/collapsible-tree',
+  '@sxywu/introduction-to-svg-and-d3-js',
+  '@d3/sankey-component',
+  '@d3/zoomable-circle-packing',
+  '@d3/selection-join',
+  '@bstaats/graph-visualization-introduction',
+  '@d3/color-legend',
+  '@uwdata/introducing-arquero',
+  '@mbostock/10-years-of-open-source-visualization',
+  '@nitaku/tangled-tree-visualization-ii',
+  '@makio135/give-me-colors',
+  '@johnburnmurdoch/bar-chart-race-the-most-populous-cities-in-the-world',
+  '@d3/color-schemes',
+  '@tezzutezzu/world-history-timeline',
+  '@d3/calendar',
+  '@observablehq/a-taste-of-observable',
+  '@d3/bar-chart-race',
+  '@mourner/martin-real-time-rtin-terrain-mesh',
+  '@uwdata/introduction-to-vega-lite',
+  '@mbostock/voronoi-stippling',
+  '@ben-tanen/a-tutorial-to-using-d3-force-from-someone-who-just-learned-ho',
+  '@d3/hierarchical-edge-bundling',
+  '@observablehq/introduction-to-data',
+  '@harrystevens/directly-labelling-lines',
+  '@observablehq/summary-table',
+  '@observablehq/plot-cheatsheets',
+  '@tomshanley/cheysson-color-palettes',
+  '@tophtucker/inferring-chart-type-from-autocorrelation-and-other-evils',
+  '@mitvis/introduction-to-d3',
+  '@veltman/watercolor',
+  '@veltman/centerline-labeling',
+  '@mbostock/scrubber',
+  '@observablehq/electoral-college-decision-tree',
+  '@d3/tree-component',
+  '@d3/radial-tree-component',
+  '@d3/world-tour',
+  '@observablehq/introduction-to-generators',
+  '@yurivish/peak-detection',
+  '@mkfreeman/plot-tooltip',
+  '@aboutaaron/racial-demographic-dot-density-map',
+  '@mbostock/methods-of-comparison-compared',
+  '@rreusser/gpgpu-boids',
+  '@rreusser/2d-n-body-gravity-with-poissons-equation',
+  '@bumbeishvili/data-driven-range-sliders',
+  '@observablehq/introducing-visual-dataflow',
+  '@observablehq/vega-lite',
+  '@observablehq/observable-for-jupyter-users',
+  '@observablehq/how-observable-runs',
+  '@unkleho/introducing-d3-render-truly-declarative-and-reusable-d3',
+  '@vega/a-guide-to-guides-axes-legends-in-vega',
+  '@bartok32/diy-inputs',
+  '@mbostock/polar-clock',
+  '@dakoop/learn-js-data',
+  '@mbostock/manipulating-flat-arrays',
+  '@uwdata/an-illustrated-guide-to-arquero-verbs',
+  '@daformat/rounding-polygon-corners',
+  '@yurivish/seasonal-spirals',
+  '@emamd/animating-lots-and-lots-of-circles-with-regl-js',
+  '@uwdata/data-visualization-curriculum',
+  '@d3/d3-group',
+  '@d3/tree-of-life',
+  '@d3/arc-diagram',
+  '@d3/choropleth',
+  '@mattdzugan/generative-art-using-wind-turbine-data',
+  '@jashkenas/handy-embed-code-generator',
+  '@analyzer2004/plot-gallery',
+  '@nsthorat/how-to-build-a-teachable-machine-with-tensorflow-js',
+  '@d3/sunburst-component',
+  '@tomlarkworthy/saas-tutorial',
+  '@mbostock/the-wealth-health-of-nations',
+  '@yy/covid-19-fatality-rate',
+  '@bryangingechen/importing-data-from-google-spreadsheets-into-a-notebook-we',
+  '@mbostock/slide',
+  '@kerryrodden/sequences-sunburst',
+  '@d3/zoom-to-bounding-box',
+  '@ambassadors/interactive-plot-dashboard',
+  '@sethpipho/fractal-tree',
+  '@mbostock/saving-svg',
+  '@analyzer2004/west-coast-weather-from-seattle-to-san-diego',
+  '@tmcw/tables',
+  '@observablehq/introduction-to-serverless-notebooks',
+  '@mootari/range-slider',
+  '@d3/animated-treemap',
+  '@d3/treemap-component',
+  '@uwdata/interaction',
+  '@hydrosquall/d3-annotation-with-d3-line-chart',
+  '@jiazhewang/introduction-to-antv',
+  '@d3/hierarchical-bar-chart',
+  '@uwdata/data-types-graphical-marks-and-visual-encoding-channels',
+  '@observablehq/why-use-a-radial-data-visualization',
+  '@kerryrodden/introduction-to-text-analysis-with-tf-idf',
+  '@uw-info474/javascript-data-wrangling',
+  '@karimdouieb/try-to-impeach-this-challenge-accepted',
+  '@observablehq/plot-gallery',
+  '@carmen-tm/women-architects-i-didnt-hear-about',
+  '@d3/versor-dragging',
+  '@analyzer2004/timespiral',
+  '@d3/brushable-scatterplot-matrix',
+  '@observablehq/require',
+  '@anjana/functional-javascript-first-steps',
+  '@hamzaamjad/tiny-charts',
+  '@observablehq/views',
+  '@yurivish/quarantine-now',
+  '@analyzer2004/performance-chart',
+  '@freedmand/sounds',
+  '@d3/bubble-chart-component',
+  '@d3/mobile-patent-suits',
+  '@observablehq/notebook-visualizer',
+  '@d3/force-directed-tree'
 ]
 )};
-const _1iotzy = function _notebook_name()
+const _yq61j2 = function _notebook_name()
 {
-    if (document.baseURI.startsWith('https://observablehq.com')) {
-        return new URL(document.baseURI).pathname.replace('/', '');
-    }
+  if (document.baseURI.startsWith('https://observablehq.com')) {
+    return new URL(document.baseURI).pathname.replace('/', '');
+  }
 };
 const _1pwnq79 = function _notebook_title(notebook_name,_runtime){return(
 notebook_name || [..._runtime.mains.keys()][0]
 )};
-const _1xzlmfy = function _utf8ToBase64(){return(
+const _433z46 = function _utf8ToBase64(){return(
 str => {
-    const bytes = new TextEncoder().encode(String(str));
-    const chunk = 32768;
-    let bin = '';
-    for (let i = 0; i < bytes.length; i += chunk) {
-        bin += String.fromCharCode(...bytes.subarray(i, i + chunk));
-    }
-    return btoa(bin);
+  const bytes = new TextEncoder().encode(String(str));
+  const chunk = 32768;
+  let bin = '';
+  for (let i = 0; i < bytes.length; i += chunk) {
+    bin += String.fromCharCode(...bytes.subarray(i, i + chunk));
+  }
+  return btoa(bin);
 }
 )};
 const _14gyvdn = function _27(md){return(
@@ -852,77 +865,77 @@ task.runtime
 const _tdkfs5 = function _runtime_variables(task_runtime,variableToObject){return(
 [...task_runtime._variables].map(variableToObject)
 )};
-const _1thre44 = function _buildModuleNames()
+const _qc5kek = function _buildModuleNames()
 {
-    return function buildModuleNames(runtime, {
-        cache = []
-    } = {}) {
-        const names = new Map();
-        for (const [module, info] of cache)
-            names.set(module, info);
-        if (runtime.mains) {
-            for (const [name, module] of runtime.mains) {
-                if (!names.has(module))
-                    names.set(module, {
-                        name,
-                        module
-                    });
+  return function buildModuleNames(runtime, {
+    cache = []
+  } = {}) {
+    const names = new Map();
+    for (const [module, info] of cache)
+      names.set(module, info);
+    if (runtime.mains) {
+      for (const [name, module] of runtime.mains) {
+        if (!names.has(module))
+          names.set(module, {
+            name,
+            module
+          });
+      }
+    }
+    // Pass 1: "module X" variables with resolved _value
+    for (const v of runtime._variables) {
+      if (typeof v._name === 'string' && v._name.startsWith('module ') && v._value && !names.has(v._value)) {
+        const name = v._name.slice(7);
+        names.set(v._value, {
+          name,
+          module: v._value
+        });
+      }
+    }
+    // Pass 2: for import-bridged variables whose source module is still unnamed,
+    // find the "module X" variable in the same module and use its name.
+    // This handles lazy/unresolved modules on Observable.
+    for (const v of runtime._variables) {
+      if (v._inputs?.length === 1 && v._inputs[0]?._module && v._inputs[0]._module !== v._module && !names.has(v._inputs[0]._module)) {
+        // Find a "module X" variable in v._module that could reference this source
+        for (const mv of runtime._variables) {
+          if (mv._module === v._module && typeof mv._name === 'string' && mv._name.startsWith('module ')) {
+            // Try to match: if mv._value is the source module, or if mv._value is unresolved
+            // but mv is the only module var, use its name
+            const targetModule = v._inputs[0]._module;
+            if (mv._value === targetModule) {
+              names.set(targetModule, {
+                name: mv._name.slice(7),
+                module: targetModule
+              });
+              break;
             }
+          }
         }
-        // Pass 1: "module X" variables with resolved _value
-        for (const v of runtime._variables) {
-            if (typeof v._name === 'string' && v._name.startsWith('module ') && v._value && !names.has(v._value)) {
-                const name = v._name.slice(7);
-                names.set(v._value, {
-                    name,
-                    module: v._value
-                });
-            }
-        }
-        // Pass 2: for import-bridged variables whose source module is still unnamed,
-        // find the "module X" variable in the same module and use its name.
-        // This handles lazy/unresolved modules on Observable.
-        for (const v of runtime._variables) {
-            if (v._inputs?.length === 1 && v._inputs[0]?._module && v._inputs[0]._module !== v._module && !names.has(v._inputs[0]._module)) {
-                // Find a "module X" variable in v._module that could reference this source
-                for (const mv of runtime._variables) {
-                    if (mv._module === v._module && typeof mv._name === 'string' && mv._name.startsWith('module ')) {
-                        // Try to match: if mv._value is the source module, or if mv._value is unresolved
-                        // but mv is the only module var, use its name
-                        const targetModule = v._inputs[0]._module;
-                        if (mv._value === targetModule) {
-                            names.set(targetModule, {
-                                name: mv._name.slice(7),
-                                module: targetModule
-                            });
-                            break;
-                        }
-                    }
-                }
-            }
-            // Also for @variable pattern imports
-            if (v._inputs?.length === 2 && v._inputs[1]?._name === '@variable' && v._inputs[0]?._value && !names.has(v._inputs[0]._value)) {
-                names.set(v._inputs[0]._value, {
-                    name: v._inputs[0]._name?.slice(7) || 'unknown',
-                    module: v._inputs[0]._value
-                });
-            }
-        }
-        const builtinModule = runtime._builtin;
-        if (builtinModule && !names.has(builtinModule))
-            names.set(builtinModule, {
-                name: 'builtin',
-                module: builtinModule
-            });
-        for (const v of runtime._variables) {
-            if (!names.has(v._module))
-                names.set(v._module, {
-                    name: 'main',
-                    module: v._module
-                });
-        }
-        return names;
-    };
+      }
+      // Also for @variable pattern imports
+      if (v._inputs?.length === 2 && v._inputs[1]?._name === '@variable' && v._inputs[0]?._value && !names.has(v._inputs[0]._value)) {
+        names.set(v._inputs[0]._value, {
+          name: v._inputs[0]._name?.slice(7) || 'unknown',
+          module: v._inputs[0]._value
+        });
+      }
+    }
+    const builtinModule = runtime._builtin;
+    if (builtinModule && !names.has(builtinModule))
+      names.set(builtinModule, {
+        name: 'builtin',
+        module: builtinModule
+      });
+    for (const v of runtime._variables) {
+      if (!names.has(v._module))
+        names.set(v._module, {
+          name: 'main',
+          module: v._module
+        });
+    }
+    return names;
+  };
 };
 const _1pfdk6e = function _isModuleVar(){return(
 v => typeof v._name === 'string' && v._name.startsWith('module ')
@@ -930,48 +943,48 @@ v => typeof v._name === 'string' && v._name.startsWith('module ')
 const _1vua7u7 = function _isDynamicVar(){return(
 v => typeof v._name === 'string' && v._name.startsWith('dynamic ')
 )};
-const _13nx5f5 = function _isImportBridged()
+const _9cxfm9 = function _isImportBridged()
 {
-    return function isImportBridged(v) {
-        if (v._inputs.length === 1 && v._inputs[0]._module !== v._module && !v._inputs[0]._name?.startsWith?.('@'))
-            return true;
-        if (v._inputs.length === 2 && v._inputs[1]?._name === '@variable')
-            return true;
-        // Observable closure-based imports: single @variable input + definition contains .import(
-        if (v._inputs.length === 1 && v._inputs[0]?._name === '@variable' && v._definition?.toString().includes('.import('))
-            return true;
-        return false;
-    };
+  return function isImportBridged(v) {
+    if (v._inputs.length === 1 && v._inputs[0]._module !== v._module && !v._inputs[0]._name?.startsWith?.('@'))
+      return true;
+    if (v._inputs.length === 2 && v._inputs[1]?._name === '@variable')
+      return true;
+    // Observable closure-based imports: single @variable input + definition contains .import(
+    if (v._inputs.length === 1 && v._inputs[0]?._name === '@variable' && v._definition?.toString().includes('.import('))
+      return true;
+    return false;
+  };
 };
-const _4l3h5t = function _findImportedName3(){return(
+const _1omyant = function _findImportedName3(){return(
 async function findImportedName(v) {
-    if (v._inputs.length === 1 && v._inputs[0]._name === '@variable') {
-        let capture;
-        await v._definition({ import: (...args) => capture = args });
-        return capture[0];
-    }
-    if (v._inputs.length === 1)
-        return v._inputs[0]._name;
-    const regex = /v\.import\("([^"]+)",\s*"([^"]+)"/;
-    const match = v._definition.toString().match(regex);
-    if (match)
-        return match[1];
-    return v._name;
+  if (v._inputs.length === 1 && v._inputs[0]._name === '@variable') {
+    let capture;
+    await v._definition({ import: (...args) => capture = args });
+    return capture[0];
+  }
+  if (v._inputs.length === 1)
+    return v._inputs[0]._name;
+  const regex = /v\.import\("([^"]+)",\s*"([^"]+)"/;
+  const match = v._definition.toString().match(regex);
+  if (match)
+    return match[1];
+  return v._name;
 }
 )};
-const _1r5dbt4 = function _moduleNames(task,moduleMap,task_runtime)
+const _x9dxs8 = function _moduleNames(task,moduleMap,task_runtime)
 {
-    if (task.options?.debug)
-        void 0;
-    return moduleMap(task_runtime, {
-        cache: [...task.mains.entries()].map(([name, module]) => [
-            module,
-            {
-                name,
-                module
-            }
-        ])
-    });
+  if (task.options?.debug)
+    debugger;
+  return moduleMap(task_runtime, {
+    cache: [...task.mains.entries()].map(([name, module]) => [
+      module,
+      {
+        name,
+        module
+      }
+    ])
+  });
 };
 const _2o6tia = function _38(resolve_modules){return(
 resolve_modules
@@ -979,8 +992,14 @@ resolve_modules
 const _dx8tp1 = function _39(summary){return(
 summary
 )};
-const _rd2qwz = function _excluded_module_names(){return(
-["TBD", "error", "builtin", "main", "bootloader"]
+const _ti9fu1 = function _excluded_module_names(){return(
+[
+  'TBD',
+  'error',
+  'builtin',
+  'main',
+  'bootloader'
+]
 )};
 const _po3sop = function _excluded_modules(moduleNames,excluded_module_names){return(
 new Map([...moduleNames.entries()].filter(([m, info]) => excluded_module_names.includes(info.name)))
@@ -988,85 +1007,90 @@ new Map([...moduleNames.entries()].filter(([m, info]) => excluded_module_names.i
 const _16u7vne = function _included_modules(moduleNames,excluded_module_names){return(
 new Map([...moduleNames.entries()].filter(([m, info]) => !excluded_module_names.includes(info.name)))
 )};
-const _1y5e5x8 = async function _module_specs(task,included_modules,TRACE_MODULE,task_runtime,isModuleVar,isDynamicVar,getFileAttachments,main,generate_module_source,moduleNames)
+const _kxkh98 = async function _module_specs(task,included_modules,TRACE_MODULE,task_runtime,isModuleVar,isDynamicVar,getFileAttachments,main,generate_module_source,moduleNames)
 {
-    if (task.options?.debug)
-        void 0;
-    return new Map(await Promise.all([...included_modules.entries()].map(async ([module, spec]) => {
-        if (spec.name === TRACE_MODULE)
-            void 0;
-        // Raw variables for this module (user-defined, non-dynamic)
-        const variables = [...task_runtime._variables].filter(v => v._module === module && (v._type === 1 || isModuleVar(v)) && !isDynamicVar(v));
-        const imports = variables.filter(v => isModuleVar(v)).map(v => v._name.slice(7)).filter(m => !['builtin'].includes(m));
-        const fileAttachments = getFileAttachments(module) || new Map();
-        if (spec.name === task.notebook && task?.options?.main_files !== false) {
-            getFileAttachments(main).forEach((value, key) => fileAttachments.set(key, value));
-        }
-        const source = await generate_module_source(spec, variables, fileAttachments, { moduleNames });
-        return [
-            spec.name,
-            {
-                url: spec.name,
-                imports,
-                fileAttachments,
-                source,
-                variables,
-                module,
-                define: spec.define
-            }
-        ];
-    })));
+  if (task.options?.debug)
+    debugger;
+  return new Map(await Promise.all([...included_modules.entries()].map(async ([module, spec]) => {
+    if (spec.name === TRACE_MODULE)
+      debugger;
+    // Raw variables for this module (user-defined, non-dynamic)
+    const variables = [...task_runtime._variables].filter(v => v._module === module && (v._type === 1 || isModuleVar(v)) && !isDynamicVar(v));
+    const imports = variables.filter(v => isModuleVar(v)).map(v => v._name.slice(7)).filter(m => !['builtin'].includes(m));
+    const fileAttachments = getFileAttachments(module) || new Map();
+    if (spec.name === task.notebook && task?.options?.main_files !== false) {
+      getFileAttachments(main).forEach((value, key) => fileAttachments.set(key, value));
+    }
+    const source = await generate_module_source(spec, variables, fileAttachments, { moduleNames });
+    return [
+      spec.name,
+      {
+        url: spec.name,
+        imports,
+        fileAttachments,
+        source,
+        variables,
+        module,
+        define: spec.define
+      }
+    ];
+  })));
 };
 const _1r3eg9r = function _findImports(){return(
 cells => [...cells.keys()].filter(name => typeof name === 'string' && name.startsWith('module ')).map(name => name.replace('module ', ''))
 )};
-const _ipv4ft = function _getFileAttachments(){return(
+const _15bukmh = function _getFileAttachments(){return(
 module => {
-    let fileMap;
-    const FileAttachment = module._builtins.get('FileAttachment');
-    const backup_get = Map.prototype.get;
-    const backup_has = Map.prototype.has;
-    Map.prototype.has = Map.prototype.get = function (...args) {
-        fileMap = this;
-    };
-    try {
-        FileAttachment('');
-    } catch (e) {
-    }
-    Map.prototype.has = backup_has;
-    Map.prototype.get = backup_get;
-    return fileMap;
+  let fileMap;
+  const FileAttachment = module._builtins.get('FileAttachment');
+  const backup_get = Map.prototype.get;
+  const backup_has = Map.prototype.has;
+  Map.prototype.has = Map.prototype.get = function (...args) {
+    fileMap = this;
+  };
+  try {
+    FileAttachment('');
+  } catch (e) {
+  }
+  Map.prototype.has = backup_has;
+  Map.prototype.get = backup_get;
+  return fileMap;
 }
 )};
-const _strmord = function _streamingModuleOrder(){return(
-(mainNames, specByName) => {
-  // Deterministic, churn-free order: bootconf-declared mains first so a notebook's own page/entry
-  // modules stream before anything else, then every other module — each group sorted alphabetically.
-  // Order depends only on the set of module names (not on the import graph), so re-exporting an
-  // unchanged notebook produces byte-identical block order. Each module's FileAttachment blocks
-  // already precede its source (see lopemodule), so define-time contentSync never misses.
-  const mains = new Set(mainNames.filter((n) => specByName.has(n)));
-  const lead = [...mains].sort();
-  const rest = [...specByName.keys()].filter((n) => !mains.has(n)).sort();
-  return [...lead, ...rest];
-}
-)};
-const _fb2vp1 = function _book(task,inlineModule,inlineGzipModule,es_module_shims,runtime_gz,inspector_gz,module_specs,lopemodule,lopebook,streamingModuleOrder){return(
-(async () => {
-  const cssBlocks = task.options.style.map(([url, content]) => inlineModule(url, content, { mime: 'text/css' })).join('\n');
-  const cssUrls = task.options.style.map(([url]) => url);
-  const systemBlocks = [
-    inlineGzipModule('es-module-shims@2.6.2', es_module_shims),
-    inlineGzipModule('@observablehq/runtime@6.0.0', runtime_gz),
-    inlineGzipModule('@observablehq/inspector@5.0.1', inspector_gz)
-  ].join('\n');
-  const orderedNames = streamingModuleOrder([...task.mains.keys()], module_specs);
-  const userBlocks = (await Promise.all(orderedNames.map(name => lopemodule(module_specs.get(name))))).join('');
-  const bootloader = task.options.bootloader || '@tomlarkworthy/bootloader';
-  const tickLine = task.options.tick != null ? `,\n  "tick": ${ JSON.stringify(task.options.tick) }` : '';
-  const tickDelayLine = task.options.tickDelayMs != null ? `,\n  "tickDelayMs": ${ JSON.stringify(task.options.tickDelayMs) }` : '';
-  const prerenderLine = task.options.prerender ? `,\n  "prerender": true` : '';
-  const bootconfBlock = `<script id="bootconf.json"
+const _g0wr2v = function _streamingModuleOrder()
+{
+  return (mainNames, specByName) => {
+    // Deterministic, churn-free order: bootconf-declared mains first so a notebook's own page/entry
+    // modules stream before anything else, then every other module — each group sorted alphabetically.
+    // Order depends only on the set of module names (not on the import graph), so re-exporting an
+    // unchanged notebook produces byte-identical block order. Each module's FileAttachment blocks
+    // already precede its source (see lopemodule), so define-time contentSync never misses.
+    const mains = new Set(mainNames.filter(n => specByName.has(n)));
+    const lead = [...mains].sort();
+    const rest = [...specByName.keys()].filter(n => !mains.has(n)).sort();
+    return [
+      ...lead,
+      ...rest
+    ];
+  };
+};
+const _e1usrg = function _book(task,inlineModule,inlineGzipModule,es_module_shims,runtime_gz,inspector_gz,streamingModuleOrder,module_specs,lopemodule,lopebook)
+{
+  return (async () => {
+    const cssBlocks = task.options.style.map(([url, content]) => inlineModule(url, content, { mime: 'text/css' })).join('\n');
+    const cssUrls = task.options.style.map(([url]) => url);
+    const systemBlocks = [
+      inlineGzipModule('es-module-shims@2.6.2', es_module_shims),
+      inlineGzipModule('@observablehq/runtime@6.0.0', runtime_gz),
+      inlineGzipModule('@observablehq/inspector@5.0.1', inspector_gz)
+    ].join('\n');
+    const orderedNames = streamingModuleOrder([...task.mains.keys()], module_specs);
+    const userBlocks = (await Promise.all(orderedNames.map(name => lopemodule(module_specs.get(name))))).join('');
+    const bootloader = task.options.bootloader || '@tomlarkworthy/bootloader';
+    const tickLine = task.options.tick != null ? `,\n  "tick": ${ JSON.stringify(task.options.tick) }` : '';
+    const tickDelayLine = task.options.tickDelayMs != null ? `,\n  "tickDelayMs": ${ JSON.stringify(task.options.tickDelayMs) }` : '';
+    const prerenderLine = task.options.prerender ? `,\n  "prerender": true` : '';
+    const bootconfBlock = `<script id="bootconf.json"
         type="text/plain"
         data-mime="application/json"
 >
@@ -1076,22 +1100,22 @@ const _fb2vp1 = function _book(task,inlineModule,inlineGzipModule,es_module_shim
   "headless": ${ !!task.options.headless }${ tickLine }${ tickDelayLine }${ prerenderLine }
 }
 </scr` + `ipt>`;
-  // Prerender: bake the live lopepage-2 chrome+content into <body> so the page shows
-  // (styled, no JS) before boot, then a MutationObserver removes it once the real
-  // #lopepage-2 mounts. Snapshot captured in exportToHTML (browser side).
-  const themeCss = (task.options.style || []).map(([, content]) => content).join('\n');
-  // Prerender: nest the snapshot in a Declarative Shadow DOM so it renders (styled, no JS)
-  // yet is invisible to the booting runtime's document queries. Theme CSS goes OUTSIDE (so
-  // its :root custom props inherit into the shadow) and INSIDE (component rules match shadow
-  // content). The host overlay sits on top (opaque, high z-index) covering the still-booting
-  // live page, then is removed (hard swap) as soon as the live page renders its first cell.
-  const prerenderBlock = (task.options.prerender && task.options.prerenderHTML) ? [
-    `<style id="lope-prerender-style">
+    // Prerender: bake the live lopepage-2 chrome+content into <body> so the page shows
+    // (styled, no JS) before boot, then a MutationObserver removes it once the real
+    // #lopepage-2 mounts. Snapshot captured in exportToHTML (browser side).
+    const themeCss = (task.options.style || []).map(([, content]) => content).join('\n');
+    // Prerender: nest the snapshot in a Declarative Shadow DOM so it renders (styled, no JS)
+    // yet is invisible to the booting runtime's document queries. Theme CSS goes OUTSIDE (so
+    // its :root custom props inherit into the shadow) and INSIDE (component rules match shadow
+    // content). The host overlay sits on top (opaque, high z-index) covering the still-booting
+    // live page, then is removed (hard swap) as soon as the live page renders its first cell.
+    const prerenderBlock = task.options.prerender && task.options.prerenderHTML ? [
+      `<style id="lope-prerender-style">
 ${ themeCss }
 #lope-prerender { position: fixed; inset: 0; z-index: 2147483000; overflow: hidden; background: var(--theme-background, #fff); }
 </style>`,
-    `<div id="lope-prerender"><template shadowrootmode="open"><style>\n${ themeCss }\n</style>${ task.options.prerenderHTML }</template></div>`,
-    `<script id="lope-prerender-cleanup">
+      `<div id="lope-prerender"><template shadowrootmode="open"><style>\n${ themeCss }\n</style>${ task.options.prerenderHTML }</template></div>`,
+      `<script id="lope-prerender-cleanup">
 (function () {
   var pr = document.getElementById('lope-prerender');
   if (!pr) return;
@@ -1104,88 +1128,88 @@ ${ themeCss }
   setTimeout(function () { mo.disconnect(); drop(); }, 5000); // never linger
 })();
 </scr` + `ipt>`
-  ].join('\n') : '';
-  const bootloaderBlock = inlineModule(bootloader, await (await fetch(`https://api.observablehq.com/${ bootloader }.js?v=4`)).text());
-  const blocks = [
-    '<!-- CSS -->',
-    cssBlocks,
-    `<style>
+    ].join('\n') : '';
+    const bootloaderBlock = inlineModule(bootloader, await (await fetch(`https://api.observablehq.com/${ bootloader }.js?v=4`)).text());
+    const blocks = [
+      '<!-- CSS -->',
+      cssBlocks,
+      `<style>
 body .inputs-3a86ea-table thead th {
   background: var(--theme-foreground-faintest);
 }
 </style>`,
-    '<!-- System Modules -->',
-    systemBlocks,
-    userBlocks,
-    '<!-- Bootloader -->',
-    bootconfBlock,
-    bootloaderBlock
-  ].join('\n');
-  return lopebook({
-    blocks,
-    cssUrls,
-    bootloader,
-    bodyPrepend: prerenderBlock,
-    title: task.options.title || (typeof document !== 'undefined' && document.title) || 'Lopecode notebook',
-    description: task.options.description,
-    image: task.options.image,
-    metas: task.options.metas,
-    head: task.options.head
-  });
-})()
-)};
-const _18javdl = function _47(Inputs,module_specs){return(
+      '<!-- System Modules -->',
+      systemBlocks,
+      userBlocks,
+      '<!-- Bootloader -->',
+      bootconfBlock,
+      bootloaderBlock
+    ].join('\n');
+    return lopebook({
+      blocks,
+      cssUrls,
+      bootloader,
+      bodyPrepend: prerenderBlock,
+      title: task.options.title || typeof document !== 'undefined' && document.title || 'Lopecode notebook',
+      description: task.options.description,
+      image: task.options.image,
+      metas: task.options.metas,
+      head: task.options.head
+    });
+  })();
+};
+const _tztkf6 = function _48(Inputs,module_specs){return(
 Inputs.table([...module_specs.entries().map(([name, spec]) => ({
+    name,
+    source: spec.source.length,
+    imports: spec.imports,
+    fileAttachments: spec.fileAttachments
+  }))], {
+  layout: 'auto',
+  format: {
+    fileAttachments: f => !f ? 'none' : Inputs.table([...f.entries().map(([name, f]) => ({
         name,
-        source: spec.source.length,
-        imports: spec.imports,
-        fileAttachments: spec.fileAttachments
-    }))], {
-    layout: 'auto',
-    format: {
-        fileAttachments: f => !f ? 'none' : Inputs.table([...f.entries().map(([name, f]) => ({
-                name,
-                url: f.url || f
-            }))]),
-        imports: f => Inputs.table(f.map(i => ({ name: i })))
-    }
+        url: f.url || f
+      }))]),
+    imports: f => Inputs.table(f.map(i => ({ name: i })))
+  }
 })
 )};
-const _1gb47v = function _48(md){return(
+const _1razd4c = function _49(md){return(
 md`##### Generate a report on the sizes of components`
 )};
-const _5m8hbe = function _report(DOMParser,book)
+const _avn3ei = function _report(DOMParser,book)
 {
-    let report;
-    try {
-        report = [...new DOMParser().parseFromString(book, 'text/html').querySelectorAll('script')].map(script => ({
-            ...script.getAttribute('file') && {
-                file: script.getAttribute('file'),
-                module: script.getAttribute('module')
-            },
-            type: script.getAttribute('data-mime') || 'application/javascript',
-            size: script.text.length,
-            id: script.id
-        }));
-    } catch (err) {
-        report = err;
-    }
-    console.log('report', report);
-    return report;
+  let report;
+  try {
+    report = [...new DOMParser().parseFromString(book, 'text/html').querySelectorAll('script')].map(script => ({
+      ...script.getAttribute('file') && {
+        file: script.getAttribute('file'),
+        module: script.getAttribute('module')
+      },
+      type: script.getAttribute('data-mime') || 'application/javascript',
+      size: script.text.length,
+      id: script.id
+    }));
+  } catch (err) {
+    report = err;
+  }
+  console.log('report', report);
+  return report;
 };
-const _4x0qc2 = function _tomlarkworthy_exporter_task(book,report,exporter_module,$0)
+const _186iat6 = function _tomlarkworthy_exporter_task(book,report,exporter_module,$0)
 {
-    const result = {
-        source: book,
-        report: report
-    };
-    exporter_module;
-    return $0.resolve(result);
+  const result = {
+    source: book,
+    report: report
+  };
+  exporter_module;
+  return $0.resolve(result);
 };
-const _1exq2jt = function _51(md){return(
+const _9aqzbs = function _52(md){return(
 md`## Module Source Generator`
 )};
-const _fctoc0 = function _52(md){return(
+const _1h8zj4h = function _53(md){return(
 md`### exportModuleJS
 
 Serialize a single module from the live runtime to a \`.js\` module source string. Unlike \`module_specs\` (which serializes all modules as part of the full HTML export pipeline), \`exportModuleJS\` works on-demand against the live runtime with no \`task\` dependency.
@@ -1208,12 +1232,9 @@ const {source, fileAttachments} = await exportModuleJS(moduleId, {runtime, modul
 - \`fileAttachments\` — \`Map<name, {url, mimeType}>\` of the module's file attachments
 `
 )};
-const _85q15a = function _exportModuleJS(_runtime,buildModuleNames,isModuleVar,isDynamicVar,getFileAttachments,generate_module_source)
+const _1xx9ynh = function _exportModuleJS(_runtime,buildModuleNames,isModuleVar,isDynamicVar,getFileAttachments,generate_module_source)
 {
-  const fn = async (
-    moduleId,
-    { runtime = _runtime, moduleNamesFn = buildModuleNames } = {}
-  ) => {
+  const fn = async (moduleId, {runtime = _runtime, moduleNamesFn = buildModuleNames} = {}) => {
     const names = moduleNamesFn(runtime);
     let targetModule = null;
     for (const [module, info] of names) {
@@ -1222,21 +1243,12 @@ const _85q15a = function _exportModuleJS(_runtime,buildModuleNames,isModuleVar,i
         break;
       }
     }
-    if (!targetModule) throw new Error(`Module not found: ${moduleId}`);
-    const variables = [...runtime._variables].filter(
-      (v) =>
-        v._module === targetModule &&
-        (v._type === 1 || isModuleVar(v)) &&
-        !isDynamicVar(v)
-    );
+    if (!targetModule)
+      throw new Error(`Module not found: ${ moduleId }`);
+    const variables = [...runtime._variables].filter(v => v._module === targetModule && (v._type === 1 || isModuleVar(v)) && !isDynamicVar(v));
     const fileAttachments = getFileAttachments(targetModule) || new Map();
     const spec = { name: moduleId };
-    const source = await generate_module_source(
-      spec,
-      variables,
-      fileAttachments,
-      { moduleNames: names }
-    );
+    const source = await generate_module_source(spec, variables, fileAttachments, { moduleNames: names });
     return {
       source,
       fileAttachments
@@ -1252,27 +1264,27 @@ ${ await generate_define(spec, variables, fileAttachments, { moduleNames }) }`
 const _19ft5zb = function _generate_definitions(variableToDefinition){return(
 variables => variables.map(v => variableToDefinition(v)).join('')
 )};
-const _7nr512 = function _generate_define(variableToDefine) {
-    return async (spec, variables, fileAttachments, {moduleNames} = {}) => {
-        const fileAttachmentExpression = fileAttachments?.size ? `  const fileAttachments = new Map(${ JSON.stringify([...fileAttachments.keys()]) }.map((name) => {
+const _u3aown = function _generate_define(variableToDefine){return(
+async (spec, variables, fileAttachments, {moduleNames} = {}) => {
+  const fileAttachmentExpression = fileAttachments?.size ? `  const fileAttachments = new Map(${ JSON.stringify([...fileAttachments.keys()]) }.map((name) => {
     const module_name = "${ spec.name }";
     const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
     const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
     return [name, {url: blob_url, mimeType: mime}]
   }));
   main.builtin("FileAttachment", runtime.fileAttachments(name => fileAttachments.get(name)));\n` : '';
-        const varLines = (await Promise.all(variables.map(v => variableToDefine(v, { moduleNames })))).flat();
-        const definedModules = new Set(varLines.filter(l => l.includes('runtime.module(')).map(l => {
-            const m = l.match(/main\.define\("module ([^"]+)"/);
-            return m ? m[1] : null;
-        }).filter(Boolean));
-        const referencedModules = new Set(varLines.map(l => {
-            const m = l.match(/\["module ([^"]+)", "@variable"\]/);
-            return m ? m[1] : null;
-        }).filter(Boolean));
-        const missingModules = [...referencedModules].filter(m => !definedModules.has(m));
-        const moduleDefineLines = missingModules.map(m => `  main.define("module ${ m }", async () => runtime.module((await importShim("/${ m }.js?v=4")).default));`);
-        return `export default function define(runtime, observer) {
+  const varLines = (await Promise.all(variables.map(v => variableToDefine(v, { moduleNames })))).flat();
+  const definedModules = new Set(varLines.filter(l => l.includes('runtime.module(')).map(l => {
+    const m = l.match(/main\.define\("module ([^"]+)"/);
+    return m ? m[1] : null;
+  }).filter(Boolean));
+  const referencedModules = new Set(varLines.map(l => {
+    const m = l.match(/\["module ([^"]+)", "@variable"\]/);
+    return m ? m[1] : null;
+  }).filter(Boolean));
+  const missingModules = [...referencedModules].filter(m => !definedModules.has(m));
+  const moduleDefineLines = missingModules.map(m => `  main.define("module ${ m }", async () => runtime.module((await importShim("/${ m }.js?v=4")).default));`);
+  return `export default function define(runtime, observer) {
   const main = runtime.module();
   const $def = (pid, name, deps, fn) => {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
@@ -1281,128 +1293,148 @@ ${ fileAttachmentExpression }${ moduleDefineLines.join('  \n') }
 ${ varLines.join('  \n') }
   return main;
 }`;
-    };
-};
+}
+)};
 const _1hslsmt = function _isLiveImport(){return(
 v => !v._name && v._definition?.toString().includes('observablehq' + '--inspect ' + 'observablehq--import')
 )};
-const _g39v22 = function _variableToDefinition(isModuleVar,isImportBridged,isLiveImport,isDynamicVar,pid,restoreCanonicalImports){return(
+const _4i5mmq = function _variableToDefinition(isModuleVar,isImportBridged,isLiveImport,isDynamicVar,pid,restoreCanonicalImports){return(
 function variableToDefinition(v) {
-    if (isModuleVar(v))
-        return '';
-    if (isImportBridged(v))
-        return '';
-    if (isLiveImport(v))
-        return '';
-    if (isDynamicVar(v))
-        return '';
-    return `const ${ pid(v) } = ${ restoreCanonicalImports(v._definition.toString()) };\n`;
+  if (isModuleVar(v))
+    return '';
+  if (isImportBridged(v))
+    return '';
+  if (isLiveImport(v))
+    return '';
+  if (isDynamicVar(v))
+    return '';
+  return `const ${ pid(v) } = ${ restoreCanonicalImports(v._definition.toString()) };\n`;
 }
 )};
-const _5zomoj = function _restoreCanonicalImports(acorn,escodegen){return(
+const _79c94t = function _restoreCanonicalImports(acorn){return(
 source => {
-    if (!/\bimportShim\s*\(/.test(source))
-        return source;
-    let ast;
-    try {
-        ast = acorn.Parser.parse(source, {
-            ecmaVersion: 'latest',
-            sourceType: 'script',
-            allowAwaitOutsideFunction: true,
-            allowReturnOutsideFunction: true,
-            allowImportExportEverywhere: true
-        });
-    } catch (e) {
-        console.warn('[exporter-3] importShim AST parse failed; leaving cell unchanged:', e.message);
-        return source;
+  if (!/\bimportShim\s*\(/.test(source))
+    return source;
+  let ast;
+  try {
+    ast = acorn.Parser.parse(source, {
+      ecmaVersion: 'latest',
+      sourceType: 'script',
+      allowAwaitOutsideFunction: true,
+      allowReturnOutsideFunction: true,
+      allowImportExportEverywhere: true
+    });
+  } catch (e) {
+    console.warn('[exporter-3] importShim AST parse failed; leaving cell unchanged:', e.message);
+    return source;
+  }
+  // The rewrite is local: only the callee identifier changes, plus the parent
+  // URL Observable appends. Collect character ranges and splice them, rather
+  // than regenerating the cell, so comments, quote style and indentation
+  // survive. Same approach as the toolchain's source-preserving observableToJs.
+  const edits = [];
+  const visit = node => {
+    if (!node || typeof node !== 'object')
+      return;
+    if (node.type === 'CallExpression' && node.callee && node.callee.type === 'Identifier' && node.callee.name === 'importShim' && node.arguments.length >= 1) {
+      edits.push([
+        node.callee.start,
+        node.callee.end,
+        'import'
+      ]);
+      // Observable compiles a cell's `import(x)` to `importShim(x, "<notebook
+      // url>")`, where argument 2 is the es-module-shims parent. Native import
+      // takes an options object there, so a string second argument is dropped
+      // and an object one (import attributes) is kept.
+      const [spec, second] = node.arguments;
+      if (node.arguments.length === 2 && second.type === 'Literal' && typeof second.value === 'string')
+        edits.push([
+          spec.end,
+          second.end,
+          ''
+        ]);
     }
-    const visit = node => {
-        if (!node || typeof node !== 'object')
-            return;
-        if (node.type === 'CallExpression' && node.callee && node.callee.type === 'Identifier' && node.callee.name === 'importShim' && node.arguments.length >= 1) {
-            const spec = node.arguments[0];
-            for (const k of Object.keys(node))
-                delete node[k];
-            node.type = 'ImportExpression';
-            node.source = spec;
-        }
-        for (const k of Object.keys(node)) {
-            const v = node[k];
-            if (Array.isArray(v))
-                v.forEach(visit);
-            else if (v && typeof v === 'object' && v.type)
-                visit(v);
-        }
-    };
-    visit(ast);
-    return escodegen.generate(ast);
+    for (const k of Object.keys(node)) {
+      const v = node[k];
+      if (Array.isArray(v))
+        v.forEach(visit);
+      else if (v && typeof v === 'object' && v.type)
+        visit(v);
+    }
+  };
+  visit(ast);
+  let out = source;
+  // Descending, so earlier offsets stay valid as we rewrite.
+  for (const [start, end, text] of edits.sort((a, b) => b[0] - a[0]))
+    out = out.slice(0, start) + text + out.slice(end);
+  return out;
 }
 )};
-const _1g36je3 = function _variableToDefine(isLiveImport,isDynamicVar,isModuleVar,isImportBridged,findImportedName3,pid)
+const _1g13ozv = function _variableToDefine(isLiveImport,isDynamicVar,isModuleVar,isImportBridged,findImportedName3,pid)
 {
-    const EXCLUDED = [
-        'main',
-        'builtin',
-        'TBD',
-        'error'
-    ];
-    return async function variableToDefine(v, {moduleNames} = {}) {
-        if (isLiveImport(v))
-            return [];
-        if (isDynamicVar(v))
-            return [];
-        if (isModuleVar(v)) {
-            // On Observable, module vars may be named "module 1" instead of "module @author/name"
-            // Look up the proper name via moduleNames map (keyed by module object)
-            let moduleName = v._name.slice(7);
-            if (v._value && moduleNames?.has(v._value)) {
-                moduleName = moduleNames.get(v._value).name;
-            }
-            if (EXCLUDED.includes(moduleName))
-                return [];
-            return [`  main.define("module ${ moduleName }", async () => runtime.module((await import("/${ moduleName }.js?v=4")).default));`];
+  const EXCLUDED = [
+    'main',
+    'builtin',
+    'TBD',
+    'error'
+  ];
+  return async function variableToDefine(v, {moduleNames} = {}) {
+    if (isLiveImport(v))
+      return [];
+    if (isDynamicVar(v))
+      return [];
+    if (isModuleVar(v)) {
+      // On Observable, module vars may be named "module 1" instead of "module @author/name"
+      // Look up the proper name via moduleNames map (keyed by module object)
+      let moduleName = v._name.slice(7);
+      if (v._value && moduleNames?.has(v._value)) {
+        moduleName = moduleNames.get(v._value).name;
+      }
+      if (EXCLUDED.includes(moduleName))
+        return [];
+      return [`  main.define("module ${ moduleName }", async () => runtime.module((await import("/${ moduleName }.js?v=4")).default));`];
+    }
+    if (isImportBridged(v)) {
+      const importedName = await findImportedName3(v);
+      let moduleVarName = null;
+      if (v._inputs.length === 2 && v._inputs[1]?._name === '@variable') {
+        // Also resolve the module var name for imports
+        const moduleVar = v._inputs[0];
+        let resolvedModuleName = moduleVar._name?.slice(7);
+        if (moduleVar._value && moduleNames?.has(moduleVar._value)) {
+          resolvedModuleName = moduleNames.get(moduleVar._value).name;
         }
-        if (isImportBridged(v)) {
-            const importedName = await findImportedName3(v);
-            let moduleVarName = null;
-            if (v._inputs.length === 2 && v._inputs[1]?._name === '@variable') {
-                // Also resolve the module var name for imports
-                const moduleVar = v._inputs[0];
-                let resolvedModuleName = moduleVar._name?.slice(7);
-                if (moduleVar._value && moduleNames?.has(moduleVar._value)) {
-                    resolvedModuleName = moduleNames.get(moduleVar._value).name;
-                }
-                moduleVarName = `module ${ resolvedModuleName }`;
-            } else if (v._inputs.length === 1 && v._inputs[0]?._name === '@variable') {
-                // Observable closure-based import: single @variable input, module captured in closure.
-                // Find source module by searching which module's _scope contains this variable name.
-                for (const [mod, info] of moduleNames) {
-                    if (info.name === 'main' || info.name === 'builtin')
-                        continue;
-                    if (mod._scope?.has(v._name)) {
-                        moduleVarName = `module ${ info.name }`;
-                        break;
-                    }
-                }
-            } else if (v._inputs.length === 1 && v._inputs[0]._module !== v._module) {
-                const sourceModule = v._inputs[0]._module;
-                const sourceInfo = moduleNames?.get(sourceModule);
-                if (sourceInfo)
-                    moduleVarName = `module ${ sourceInfo.name }`;
-            }
-            if (!moduleVarName)
-                return [];
-            const resolvedName = moduleVarName.slice(7);
-            if (EXCLUDED.includes(resolvedName))
-                return [];
-            return [`  main.define("${ v._name }", ["${ moduleVarName }", "@variable"], (_, v) => v.import(${ importedName && importedName !== v._name ? `"${ importedName }", ` : '' }"${ v._name }", _));`];
+        moduleVarName = `module ${ resolvedModuleName }`;
+      } else if (v._inputs.length === 1 && v._inputs[0]?._name === '@variable') {
+        // Observable closure-based import: single @variable input, module captured in closure.
+        // Find source module by searching which module's _scope contains this variable name.
+        for (const [mod, info] of moduleNames) {
+          if (info.name === 'main' || info.name === 'builtin')
+            continue;
+          if (mod._scope?.has(v._name)) {
+            moduleVarName = `module ${ info.name }`;
+            break;
+          }
         }
-        const deps = JSON.stringify(v._inputs.map(i => i._name));
-        const name_literal = v._name ? `"${ v._name }"` : 'null';
-        return [`  $def("${ pid(v) }", ${ name_literal }, ${ deps }, ${ pid(v) });`];
-    };
+      } else if (v._inputs.length === 1 && v._inputs[0]._module !== v._module) {
+        const sourceModule = v._inputs[0]._module;
+        const sourceInfo = moduleNames?.get(sourceModule);
+        if (sourceInfo)
+          moduleVarName = `module ${ sourceInfo.name }`;
+      }
+      if (!moduleVarName)
+        return [];
+      const resolvedName = moduleVarName.slice(7);
+      if (EXCLUDED.includes(resolvedName))
+        return [];
+      return [`  main.define("${ v._name }", ["${ moduleVarName }", "@variable"], (_, v) => v.import(${ importedName && importedName !== v._name ? `"${ importedName }", ` : '' }"${ v._name }", _));`];
+    }
+    const deps = JSON.stringify(v._inputs.map(i => i._name));
+    const name_literal = v._name ? `"${ v._name }"` : 'null';
+    return [`  $def("${ pid(v) }", ${ name_literal }, ${ deps }, ${ pid(v) });`];
+  };
 };
-const _dxkjia = function _61(md){return(
+const _8rymrb = function _62(md){return(
 md`## Assemble `
 )};
 const _g33g3u = function _es_module_shims(){return(
@@ -1429,107 +1461,185 @@ ${ source }
 const _bwex58 = function _normalize(){return(
 url => url.replace(/^(?:https:\/\/api\.observablehq\.com)?\/(.*?)\.js(?:\?.*)?$/, '$1').replace(/^(d\/[a-f0-9]{16})@\d+$/, '$1')
 )};
-const _eoywzy = function _test_normalize(expect,normalize)
+const _1vymoni = function _test_normalize(expect,normalize)
 {
-    expect(normalize('d/57d79353bac56631@4')).toBe('d/57d79353bac56631');
-    expect(normalize('https://api.observablehq.com/@tomlarkworthy/runtime-sdk.js?v=4')).toBe('@tomlarkworthy/runtime-sdk');
-    expect(normalize('https://api.observablehq.com/@tomlarkworthy/bootloader.js?v=4')).toBe('@tomlarkworthy/bootloader');
-    expect(normalize('https://api.observablehq.com/d/57d79353bac56631.js?v=4')).toBe('d/57d79353bac56631');
-    expect(normalize('/@tomlarkworthy/runtime-sdk.js?v=4')).toBe('@tomlarkworthy/runtime-sdk');
-    expect(normalize('/d/57d79353bac56631.js?v=4')).toBe('d/57d79353bac56631');
-    expect(normalize('/@tomlarkworthy/fileattachments.js?v=4&resolutions=4b0160c7af70b609@8453')).toBe('@tomlarkworthy/fileattachments');
-    expect(normalize('https://api.observablehq.com/@tomlarkworthy/jest-expect-standalone.js?v=4&resolutions=03dda470c56b93ff@8390')).toBe('@tomlarkworthy/jest-expect-standalone');
+  expect(normalize('d/57d79353bac56631@4')).toBe('d/57d79353bac56631');
+  expect(normalize('https://api.observablehq.com/@tomlarkworthy/runtime-sdk.js?v=4')).toBe('@tomlarkworthy/runtime-sdk');
+  expect(normalize('https://api.observablehq.com/@tomlarkworthy/bootloader.js?v=4')).toBe('@tomlarkworthy/bootloader');
+  expect(normalize('https://api.observablehq.com/d/57d79353bac56631.js?v=4')).toBe('d/57d79353bac56631');
+  expect(normalize('/@tomlarkworthy/runtime-sdk.js?v=4')).toBe('@tomlarkworthy/runtime-sdk');
+  expect(normalize('/d/57d79353bac56631.js?v=4')).toBe('d/57d79353bac56631');
+  expect(normalize('/@tomlarkworthy/fileattachments.js?v=4&resolutions=4b0160c7af70b609@8453')).toBe('@tomlarkworthy/fileattachments');
+  expect(normalize('https://api.observablehq.com/@tomlarkworthy/jest-expect-standalone.js?v=4&resolutions=03dda470c56b93ff@8390')).toBe('@tomlarkworthy/jest-expect-standalone');
 };
-const _strmtest1 = function _test_networking_script_is_streaming(expect,networking_script)
+const _158qnvp = function _test_networking_script_is_streaming(networking_script,expect)
 {
-    const src = networking_script;
-    // the streaming gate + waiting helper
-    expect(src.includes("window.__lopeStreaming = true")).toBe(true);
-    expect(src.includes("function __waitForId")).toBe(true);
-    // event-driven (MutationObserver), not a setTimeout poll: robust to Safari background-tab
-    // timer throttling when a fork opens via window.open into an unfocused blob: tab
-    expect(src.includes("new MutationObserver")).toBe(true);
-    expect(src.includes("await new Promise((r) => setTimeout")).toBe(false);
-    // DOMContentLoaded/load clear the streaming flag even if the inline sentinel never runs.
-    // String checks, not regex literals: the push decompiler can't round-trip regex literals.
-    expect(src.includes('addEventListener("DOMContentLoaded", __endStreaming')).toBe(true);
-    expect(src.includes('window.addEventListener("load", __endStreaming')).toBe(true);
-    // dvfBytes (global fetch / XHR / blob path) waits for the block to stream in.
-    // Keep braces balanced everywhere in this cell (even in strings and comments): the
-    // module source extractor counts braces literally, so a stray open brace makes this
-    // cell's _definition run past its end and decompile/push silently drops it.
-    expect(src.includes("async function dvfBytes(id)")).toBe(true);
-    expect(src.includes("await __waitForId(id);")).toBe(true);
-    // es-module-shims fetch + source hooks are async and wait (es-module-shims awaits both)
-    expect(src.includes("async fetch(url, options, parent)")).toBe(true);
-    expect(src.includes("async source(url, fetchOpts, parent, defaultSourceHook)")).toBe(true);
-    const fetchIdx = src.indexOf("async fetch(url, options, parent)");
-    expect(fetchIdx).toBeGreaterThan(-1);
-    expect(src.indexOf("await __waitForId(id);", fetchIdx)).toBeGreaterThan(fetchIdx);
-    // resolve stays synchronous (es-module-shims does not await it) but keeps streaming notebook
-    // ids local instead of rewriting them to the remote observablehq API
-    expect(src.includes("\n    resolve(id, parentUrl, defaultResolve)")).toBe(true);
-    expect(src.includes("if (window.__lopeStreaming && isNotebook(id)) return")).toBe(true);
-    return "ok";
+  const src = networking_script;
+  // the streaming gate + waiting helper
+  expect(src.includes('window.__lopeStreaming = true')).toBe(true);
+  expect(src.includes('function __waitForId')).toBe(true);
+  // event-driven (MutationObserver), not a setTimeout poll: robust to Safari background-tab
+  // timer throttling when a fork opens via window.open into an unfocused blob: tab
+  expect(src.includes('new MutationObserver')).toBe(true);
+  expect(src.includes('await new Promise((r) => setTimeout')).toBe(false);
+  // DOMContentLoaded/load clear the streaming flag even if the inline sentinel never runs.
+  // String checks, not regex literals: the push decompiler can't round-trip regex literals.
+  expect(src.includes('addEventListener("DOMContentLoaded", __endStreaming')).toBe(true);
+  expect(src.includes('window.addEventListener("load", __endStreaming')).toBe(true);
+  // dvfBytes (global fetch / XHR / blob path) waits for the block to stream in.
+  // Keep braces balanced everywhere in this cell (even in strings and comments): the
+  // module source extractor counts braces literally, so a stray open brace makes this
+  // cell's _definition run past its end and decompile/push silently drops it.
+  expect(src.includes('async function dvfBytes(id)')).toBe(true);
+  expect(src.includes('await __waitForId(id);')).toBe(true);
+  // es-module-shims fetch + source hooks are async and wait (es-module-shims awaits both)
+  expect(src.includes('async fetch(url, options, parent)')).toBe(true);
+  expect(src.includes('async source(url, fetchOpts, parent, defaultSourceHook)')).toBe(true);
+  const fetchIdx = src.indexOf('async fetch(url, options, parent)');
+  expect(fetchIdx).toBeGreaterThan(-1);
+  expect(src.indexOf('await __waitForId(id);', fetchIdx)).toBeGreaterThan(fetchIdx);
+  // resolve stays synchronous (es-module-shims does not await it) but keeps streaming notebook
+  // ids local instead of rewriting them to the remote observablehq API
+  expect(src.includes('\n    resolve(id, parentUrl, defaultResolve)')).toBe(true);
+  expect(src.includes('if (window.__lopeStreaming && isNotebook(id)) return')).toBe(true);
+  return 'ok';
 };
-const _strmtest2 = function _test_lopebook_main_at_top_with_sentinel(expect,lopebook)
+const _1d9ux6v = function _test_lopebook_main_at_top_with_sentinel(lopebook,expect)
 {
-    const MARK = "<!--USER_BLOCKS_MARK-->";
-    const html = lopebook({ blocks: MARK, cssUrls: [], bootloader: "@tomlarkworthy/bootloader", title: "t" });
-    const mainIdx = html.indexOf('<script id="main">');
-    const blocksIdx = html.indexOf(MARK);
-    const sentinelIdx = html.indexOf("streaming_sentinel");
-    // main is a classic (non-deferred) script so it runs from the top during streaming
-    expect(mainIdx).toBeGreaterThan(-1);
-    expect(html.includes('<script type="module" id="main">')).toBe(false);
-    // main runs before the module blocks, the end sentinel after them
-    expect(mainIdx).toBeLessThan(blocksIdx);
-    expect(sentinelIdx).toBeGreaterThan(blocksIdx);
-    // bootstrap awaits the now-async fetch hook before reading .text()
-    expect(html.includes('.fetch("file://es-module-shims@2.6.2").then(r => r.text())')).toBe(true);
-    return "ok";
+  const MARK = '<!--USER_BLOCKS_MARK-->';
+  const html = lopebook({
+    blocks: MARK,
+    cssUrls: [],
+    bootloader: '@tomlarkworthy/bootloader',
+    title: 't'
+  });
+  const mainIdx = html.indexOf('<script id="main">');
+  const blocksIdx = html.indexOf(MARK);
+  const sentinelIdx = html.indexOf('streaming_sentinel');
+  // main is a classic (non-deferred) script so it runs from the top during streaming
+  expect(mainIdx).toBeGreaterThan(-1);
+  expect(html.includes('<script type="module" id="main">')).toBe(false);
+  // main runs before the module blocks, the end sentinel after them
+  expect(mainIdx).toBeLessThan(blocksIdx);
+  expect(sentinelIdx).toBeGreaterThan(blocksIdx);
+  // bootstrap awaits the now-async fetch hook before reading .text()
+  expect(html.includes('.fetch("file://es-module-shims@2.6.2").then(r => r.text())')).toBe(true);
+  return 'ok';
 };
-const _strmtest3 = function _test_streaming_order_prioritizes_mains(expect,streamingModuleOrder)
+const _13d3rb0 = function _test_streaming_order_prioritizes_mains(expect,streamingModuleOrder)
 {
-    const mk = (names) => new Map(names.map((n) => [n, { url: n, imports: [] }]));
-    const specByName = mk(["@u/app", "@u/lib", "@u/junk"]);
-    // single main leads, then everything else alphabetically (imports are ignored)
-    expect(streamingModuleOrder(["@u/app"], specByName).join(",")).toBe("@u/app,@u/junk,@u/lib");
-    // multiple mains are themselves alphabetical and still lead
-    expect(streamingModuleOrder(["@u/lib", "@u/app"], specByName).join(",")).toBe("@u/app,@u/lib,@u/junk");
-    // deterministic: independent of specByName insertion order
-    expect(streamingModuleOrder(["@u/app"], mk(["@u/junk", "@u/lib", "@u/app"])).join(",")).toBe("@u/app,@u/junk,@u/lib");
-    // unknown main is ignored; every module still present exactly once
-    expect(streamingModuleOrder(["@u/missing"], specByName).join(",")).toBe("@u/app,@u/junk,@u/lib");
-    return "ok";
-};
-const _strmtest4 = function _test_streaming_order_runtime(expect,Runtime,streamingModuleOrder)
-{
-    // Build a real Runtime with the module-import wiring the exporter introspects, then order it.
-    const rt = new Runtime();
-    const libMod = rt.module();
-    libMod.variable().define("x", [], () => 1);
-    const appMod = rt.module();
-    appMod.variable().define("module @u/lib", [], () => libMod); // app imports lib
-    const junkMod = rt.module();
-    junkMod.variable().define("y", [], () => 2);
-    // derive specs exactly as `module_specs` does: a module's `module ` vars are its imports
-    const names = new Map([[appMod, "@u/app"], [libMod, "@u/lib"], [junkMod, "@u/junk"]]);
-    const specByName = new Map();
-    for (const [mod, name] of names) {
-        const imports = [...rt._variables]
-            .filter(v => v._module === mod && typeof v._name === "string" && v._name.startsWith("module "))
-            .map(v => v._name.slice(7));
-        specByName.set(name, { url: name, imports });
+  const mk = names => new Map(names.map(n => [
+    n,
+    {
+      url: n,
+      imports: []
     }
-    const order = streamingModuleOrder(["@u/app"], specByName);
-    expect(order.join(",")).toBe("@u/app,@u/junk,@u/lib");   // main first, then the rest alphabetically
-    return "ok";
+  ]));
+  const specByName = mk([
+    '@u/app',
+    '@u/lib',
+    '@u/junk'
+  ]);
+  // single main leads, then everything else alphabetically (imports are ignored)
+  expect(streamingModuleOrder(['@u/app'], specByName).join(',')).toBe('@u/app,@u/junk,@u/lib');
+  // multiple mains are themselves alphabetical and still lead
+  expect(streamingModuleOrder([
+    '@u/lib',
+    '@u/app'
+  ], specByName).join(',')).toBe('@u/app,@u/lib,@u/junk');
+  // deterministic: independent of specByName insertion order
+  expect(streamingModuleOrder(['@u/app'], mk([
+    '@u/junk',
+    '@u/lib',
+    '@u/app'
+  ])).join(',')).toBe('@u/app,@u/junk,@u/lib');
+  // unknown main is ignored; every module still present exactly once
+  expect(streamingModuleOrder(['@u/missing'], specByName).join(',')).toBe('@u/app,@u/junk,@u/lib');
+  return 'ok';
+};
+const _18z61zg = function _test_streaming_order_runtime(Runtime,streamingModuleOrder,expect)
+{
+  // Build a real Runtime with the module-import wiring the exporter introspects, then order it.
+  const rt = new Runtime();
+  const libMod = rt.module();
+  libMod.variable().define('x', [], () => 1);
+  const appMod = rt.module();
+  appMod.variable().define('module @u/lib', [], () => libMod);
+  // app imports lib
+  const junkMod = rt.module();
+  junkMod.variable().define('y', [], () => 2);
+  // derive specs exactly as `module_specs` does: a module's `module ` vars are its imports
+  const names = new Map([
+    [
+      appMod,
+      '@u/app'
+    ],
+    [
+      libMod,
+      '@u/lib'
+    ],
+    [
+      junkMod,
+      '@u/junk'
+    ]
+  ]);
+  const specByName = new Map();
+  for (const [mod, name] of names) {
+    const imports = [...rt._variables].filter(v => v._module === mod && typeof v._name === 'string' && v._name.startsWith('module ')).map(v => v._name.slice(7));
+    specByName.set(name, {
+      url: name,
+      imports
+    });
+  }
+  const order = streamingModuleOrder(['@u/app'], specByName);
+  expect(order.join(',')).toBe('@u/app,@u/junk,@u/lib');
+  // main first, then the rest alphabetically
+  return 'ok';
+};
+const _1didxs7 = function _test_restoreCanonicalImports(restoreCanonicalImports,expect)
+{
+  const R = restoreCanonicalImports;
+  // Nothing to rewrite: identity.
+  expect(R('async () => 1 + 2')).toBe('async () => 1 + 2');
+  // Callee position becomes the canonical dynamic import.
+  expect(R('async () => await importShim("/@a/b.js?v=4")')).toBe('async () => await import("/@a/b.js?v=4")');
+  // Several calls of differing length: the offsets must stay valid.
+  expect(R('async () => [await importShim("a"), await importShim("bb")]')).toBe('async () => [await import("a"), await import("bb")]');
+  expect(R('async () => importShim(await importShim("inner"))')).toBe('async () => import(await import("inner"))');
+  // Argument 2 is the es-module-shims parent URL that Observable appends when
+  // it compiles a cell's own `import(x)`. Native import has no such parameter.
+  expect(R("f = () => importShim(objectURL, 'https://api.observablehq.com/@a/b.js?v=4')")).toBe('f = () => import(objectURL)');
+  expect(R('f = () => importShim(`${ nb }.js?v=4`, "https://api.observablehq.com/@a/b.js?v=4")')).toBe('f = () => import(`${ nb }.js?v=4`)');
+  // ...but a real options object is import attributes, and must survive.
+  expect(R("async () => await importShim(url, { with: { type: 'css' } })")).toBe("async () => await import(url, { with: { type: 'css' } })");
+  // Callee position only. A bare `import` identifier is a syntax error, so a
+  // reference passed as a value has to be left alone.
+  expect(R('async () => register(importShim, importShim("real"))')).toBe('async () => register(importShim, import("real"))');
+  expect(R('async () => window.importShim("x") + importShim("y")')).toBe('async () => window.importShim("x") + import("y")');
+  expect(R('async () => importShim() || importShim("x")')).toBe('async () => importShim() || import("x")');
+  // A string that merely mentions importShim is not a call.
+  expect(R('async () => { const s = "call importShim(x) later"; return importShim("real"); }')).toBe('async () => { const s = "call importShim(x) later"; return import("real"); }');
+};
+const _ogm44p = function _test_restoreCanonicalImports_preserves_source(expect,restoreCanonicalImports)
+{
+  // Only the callee identifier changes, so the rest survives byte-for-byte —
+  // escodegen used to reformat the whole cell.
+  const src = [
+    'function _f() {',
+    "  // keep  this   comment",
+    "  const s = 'single-quoted';   /* and this */",
+    '  return importShim("tpl");',
+    '}'
+  ].join('\n');
+  expect(restoreCanonicalImports(src)).toBe(src.replace('return importShim("tpl")', 'return import("tpl")'));
+  // Unparseable input falls back to the original source.
+  const broken = 'async () => importShim("unclosed';
+  expect(restoreCanonicalImports(broken)).toBe(broken);
 };
 const _1vgrzwk = function _isNotebook(){return(
 id => /^(@[^/]+\/[^/]+|d\/[a-f0-9]{16})$/.test(id)
 )};
-const _1pcnq22 = function _networking_script(normalize,isNotebook){return(
+const _1s9g3fb = function _networking_script(normalize,isNotebook){return(
 `
   const normalize = ${ normalize.toString() };
   const isNotebook = ${ isNotebook.toString() };
@@ -1718,7 +1828,7 @@ const _1pcnq22 = function _networking_script(normalize,isNotebook){return(
       const el = _create.call(this, name, opts);
       const tag = String(name).toLowerCase();
       if (tag === "script") {
-        if ( tag === "img") void 0;
+        if ( tag === "img") debugger;
         const d = Object.getOwnPropertyDescriptor(HTMLScriptElement.prototype, "src");
         Object.defineProperty(el, "src", {
           configurable: true,
@@ -1810,21 +1920,22 @@ const _1pcnq22 = function _networking_script(normalize,isNotebook){return(
     }
   })();`
 )};
-const _lq8bhb = function _lopebook(diskDataUrl, networking_script) {
-    return ({blocks = '', cssUrls = [], bootloader = '@tomlarkworthy/bootloader', title = 'Lopecode notebook', description, image, metas = [], head, bodyPrepend = ''} = {}) => {
-        const styleImports = cssUrls.map((url, i) => `  const style${ i } = await importShim(${ JSON.stringify(url) }, { with: { type: 'css' } });`).join('\n');
-        const styleAdopt = cssUrls.map((_, i) => `style${ i }.default`).join(',');
-        const attr = s => String(s).replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-        const ogTags = [
-            `<meta property="og:title" content="${ attr(title) }">`,
-            `<meta property="og:type" content="website">`,
-            description ? `<meta name="description" content="${ attr(description) }">` : '',
-            description ? `<meta property="og:description" content="${ attr(description) }">` : '',
-            image ? `<meta property="og:image" content="${ attr(image) }">` : '',
-            // Preserved <meta> carried across re-export by exportToHTML's head scan.
-            ...(metas || []).map(m => `<meta ${ m.isProperty ? 'property' : 'name' }="${ attr(m.key) }" content="${ attr(m.content) }">`)
-        ].filter(Boolean).join('\n  ');
-        return `<!DOCTYPE html>
+const _kfs9ca = function _lopebook(diskDataUrl,networking_script)
+{
+  return ({blocks = '', cssUrls = [], bootloader = '@tomlarkworthy/bootloader', title = 'Lopecode notebook', description, image, metas = [], head, bodyPrepend = ''} = {}) => {
+    const styleImports = cssUrls.map((url, i) => `  const style${ i } = await importShim(${ JSON.stringify(url) }, { with: { type: 'css' } });`).join('\n');
+    const styleAdopt = cssUrls.map((_, i) => `style${ i }.default`).join(',');
+    const attr = s => String(s).replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    const ogTags = [
+      `<meta property="og:title" content="${ attr(title) }">`,
+      `<meta property="og:type" content="website">`,
+      description ? `<meta name="description" content="${ attr(description) }">` : '',
+      description ? `<meta property="og:description" content="${ attr(description) }">` : '',
+      image ? `<meta property="og:image" content="${ attr(image) }">` : '',
+      // Preserved <meta> carried across re-export by exportToHTML's head scan.
+      ...(metas || []).map(m => `<meta ${ m.isProperty ? 'property' : 'name' }="${ attr(m.key) }" content="${ attr(m.content) }">`)
+    ].filter(Boolean).join('\n  ');
+    return `<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
@@ -1864,73 +1975,73 @@ ${ blocks }
 <script id="streaming_sentinel">window.__lopeStreaming = false;</scr\ipt>
 </body>
 </html>`;
-    };
+  };
 };
-const _lzzjtg = function _lopemodule(TRACE_MODULE,CSS,arrayBufferToBase64,inlineModule,escapeScriptTags)
+const _li7wcc = function _lopemodule(TRACE_MODULE,CSS,arrayBufferToBase64,inlineModule,escapeScriptTags)
 {
-    return async module => {
-        if (module.url === TRACE_MODULE) {
-            void 0;
-        }
-        const moduleId = module.url.replace(/^(d\/[a-f0-9]{16})@\d+$/, '$1');
-        const files = module.fileAttachments ? await Promise.all([...module.fileAttachments.entries()].map(async ([name, attachment]) => {
-            const url = attachment.url || attachment;
-            const file_url = `${ moduleId }/${ encodeURIComponent(name) }`;
-            // Get from local when possible
-            const lopefile = !url.startsWith('blob:') && document.querySelector(`script[type=lope-file][module='${ CSS.escape(module.url) }'][file='${ CSS.escape(encodeURIComponent(name)) }']`);
-            let data64, mime = undefined;
-            if (!lopefile) {
-                const response = await fetch(url);
-                data64 = await response.arrayBuffer().then(arrayBufferToBase64);
-                mime = response.headers.get('content-type');
-            } else {
-                data64 = lopefile.textContent;
-                mime = lopefile.getAttribute('mime');
-            }
-            return `<script id="${ file_url }" 
+  return async module => {
+    if (module.url === TRACE_MODULE) {
+      debugger;
+    }
+    const moduleId = module.url.replace(/^(d\/[a-f0-9]{16})@\d+$/, '$1');
+    const files = module.fileAttachments ? await Promise.all([...module.fileAttachments.entries()].map(async ([name, attachment]) => {
+      const url = attachment.url || attachment;
+      const file_url = `${ moduleId }/${ encodeURIComponent(name) }`;
+      // Get from local when possible
+      const lopefile = !url.startsWith('blob:') && document.querySelector(`script[type=lope-file][module='${ CSS.escape(module.url) }'][file='${ CSS.escape(encodeURIComponent(name)) }']`);
+      let data64, mime = undefined;
+      if (!lopefile) {
+        const response = await fetch(url);
+        data64 = await response.arrayBuffer().then(arrayBufferToBase64);
+        mime = response.headers.get('content-type');
+      } else {
+        data64 = lopefile.textContent;
+        mime = lopefile.getAttribute('mime');
+      }
+      return `<script id="${ file_url }" 
   type="text/plain"
   data-encoding="base64"
   data-mime="${ mime }"
 >
 ${ data64 }
-</scr\ipt>`;    // return `<script type="lope-file" module="${
-                //   module.url
-                // }" file="${encodeURIComponent(
-                //   name
-                // )}" mime="${mime}">${data64}</scr\ipt>\n`;
-        })) : [];
-        return `${ files.join('\n') }\n${ inlineModule(moduleId, escapeScriptTags(module.source)) }\n`;
-    };
+</scr\ipt>`;  // return `<script type="lope-file" module="${
+              //   module.url
+              // }" file="${encodeURIComponent(
+              //   name
+              // )}" mime="${mime}">${data64}</scr\ipt>\n`;
+    })) : [];
+    return `${ files.join('\n') }\n${ inlineModule(moduleId, escapeScriptTags(module.source)) }\n`;
+  };
 };
 const _19l1umr = function _escapeScriptTags(){return(
 str => str.replaceAll('</scr\ipt', '</scr\\ipt')
 )};
-const _1hwkszj = function _arrayBufferToBase64(){return(
+const _xpg7uv = function _arrayBufferToBase64(){return(
 async function arrayBufferToBase64(buffer) {
-    const bytes = new Uint8Array(buffer);
-    const binary = bytes.reduce((data, byte) => data + String.fromCharCode(byte), '');
-    return btoa(binary);
+  const bytes = new Uint8Array(buffer);
+  const binary = bytes.reduce((data, byte) => data + String.fromCharCode(byte), '');
+  return btoa(binary);
 }
 )};
-const _am38ex = function _74(md){return(
+const _1iz5onh = function _81(md){return(
 md`### Global Output`
 )};
-const _kx1h0y = function _75(md){return(
+const _b9np5w = function _82(md){return(
 md`## Utils`
 )};
-const _t237wb = function _getCompactISODate(){return(
+const _fw7q7v = function _getCompactISODate(){return(
 function getCompactISODate() {
-    const date = new Date();
-    const year = date.getUTCFullYear();
-    const month = String(date.getUTCMonth() + 1).padStart(2, '0');
-    const day = String(date.getUTCDate()).padStart(2, '0');
-    const hours = String(date.getUTCHours()).padStart(2, '0');
-    const minutes = String(date.getUTCMinutes()).padStart(2, '0');
-    const seconds = String(date.getUTCSeconds()).padStart(2, '0');
-    return `${ year }${ month }${ day }T${ hours }${ minutes }${ seconds }Z`;
+  const date = new Date();
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(date.getUTCDate()).padStart(2, '0');
+  const hours = String(date.getUTCHours()).padStart(2, '0');
+  const minutes = String(date.getUTCMinutes()).padStart(2, '0');
+  const seconds = String(date.getUTCSeconds()).padStart(2, '0');
+  return `${ year }${ month }${ day }T${ hours }${ minutes }${ seconds }Z`;
 }
 )};
-const _1nku2br = function _77(md){return(
+const _7vqfq9 = function _84(md){return(
 md`## Additional Tests`
 )};
 const _8765p8 = function _diskDataUrl(disk_svg){return(
@@ -1955,6 +2066,7 @@ export default function define(runtime, observer) {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
 
+  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
   main.define("module @tomlarkworthy/observable-runtime-v6", async () => runtime.module((await import("/@tomlarkworthy/observable-runtime-v6.js?v=4")).default));  
   main.define("module @tomlarkworthy/flow-queue", async () => runtime.module((await import("/@tomlarkworthy/flow-queue.js?v=4")).default));  
   main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
@@ -1964,12 +2076,11 @@ export default function define(runtime, observer) {
   main.define("module @tomlarkworthy/local-storage-view", async () => runtime.module((await import("/@tomlarkworthy/local-storage-view.js?v=4")).default));  
   main.define("module @tomlarkworthy/dom-view", async () => runtime.module((await import("/@tomlarkworthy/dom-view.js?v=4")).default));  
   main.define("module @tomlarkworthy/module-map", async () => runtime.module((await import("/@tomlarkworthy/module-map.js?v=4")).default));  
-  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));
-  main.define("module @tomlarkworthy/lopepage-urls", async () => runtime.module((await import("/@tomlarkworthy/lopepage-urls.js?v=4")).default));  
+  main.define("module @tomlarkworthy/runtime-sdk", async () => runtime.module((await import("/@tomlarkworthy/runtime-sdk.js?v=4")).default));  
   main.define("module @tomlarkworthy/jest-expect-standalone", async () => runtime.module((await import("/@tomlarkworthy/jest-expect-standalone.js?v=4")).default));  
   main.define("module @tomlarkworthy/themes", async () => runtime.module((await import("/@tomlarkworthy/themes.js?v=4")).default));  
   $def("_1noor04", null, ["md"], _1noor04);  
-  $def("_1xs1o58", null, ["exporter","viewof output","Event"], _1xs1o58);  
+  $def("_vpmotg", null, ["exporter","viewof output","Event"], _vpmotg);  
   $def("_16yvadj", null, ["md","downloadAnchor","forkAnchor"], _16yvadj);  
   $def("_xnho81", null, ["md","forkAnchor","downloadAnchor"], _xnho81);  
   $def("_lv8hyy", null, ["md"], _lv8hyy);  
@@ -1979,77 +2090,79 @@ export default function define(runtime, observer) {
   $def("_17bj13d", null, ["disk_svg"], _17bj13d);  
   $def("_fl78rz", "disk_svg", ["html"], _fl78rz);  
   $def("_ibwdcx", null, ["md"], _ibwdcx);  
-  $def("_4vze8h", "exporter", ["actionHandler","css","keepalive","exporter_module","variable","domView","view","disk_svg","Inputs","themes","viewof theme_assets","linkTo"], _4vze8h);
-  $def("_5xp8ad", "copyTextToClipboard", ["globalThis"], _5xp8ad);  
-  $def("_ywlem4", "htmlToConsoleSnippet", ["utf8ToBase64"], _ywlem4);  
-  $def("_1gdtxyo", "exportAnchor", ["Node","notebook_name","main","_runtime","exportToHTML","location","getCompactISODate"], _1gdtxyo);  
+  $def("_1p4bp3o", "exporter", ["actionHandler","css","keepalive","exporter_module","variable","domView","view","disk_svg","linkTo","Inputs","themes","viewof theme_assets"], _1p4bp3o);  
+  $def("_14mjs7h", "copyTextToClipboard", ["globalThis"], _14mjs7h);  
+  $def("_1sbph8c", "htmlToConsoleSnippet", ["utf8ToBase64"], _1sbph8c);  
+  $def("_1w6fc3k", "exportAnchor", ["Node","notebook_name","main","_runtime","exportToHTML","location","getCompactISODate"], _1w6fc3k);  
   $def("_1u2ju69", "forkAnchor", ["exportAnchor"], _1u2ju69);  
   $def("_1a8n42w", "downloadAnchor", ["exportAnchor"], _1a8n42w);  
-  $def("_r3bep4", "actionHandler", ["Inputs","getSourceModule","notebook_name","_runtime","exportToHTML","htmlToConsoleSnippet","copyTextToClipboard","view","location","getCompactISODate","linkTo"], _r3bep4);
-  $def("_k7go5d", "exportToHTML", ["_runtime","cssForTheme","css","location","keepalive","exporter_module","viewof task"], _k7go5d);  
-  $def("_17k9v19", "getSourceModule", ["notebook_name","main","_runtime","importShim"], _17k9v19);  
-  $def("_6vlf2p", "createShowable", ["variable","view"], _6vlf2p);  
-  $def("_zclcql", "reportValidity", [], _zclcql);  
-  $def("_10rnvxz", "top120List", [], _10rnvxz);  
-  $def("_1iotzy", "notebook_name", [], _1iotzy);  
+  $def("_4zsqot", "actionHandler", ["Inputs","getSourceModule","notebook_name","_runtime","exportToHTML","htmlToConsoleSnippet","copyTextToClipboard","view","linkTo","location","getCompactISODate"], _4zsqot);  
+  $def("_lb3gzc", "exportToHTML", ["_runtime","cssForTheme","css","location","keepalive","exporter_module","viewof task"], _lb3gzc);  
+  $def("_43zr7", "getSourceModule", ["notebook_name","main","_runtime"], _43zr7);  
+  $def("_tpv4tl", "createShowable", ["variable","view"], _tpv4tl);  
+  $def("_rnq9mt", "reportValidity", [], _rnq9mt);  
+  $def("_3vwqe7", "top120List", [], _3vwqe7);  
+  $def("_yq61j2", "notebook_name", [], _yq61j2);  
   $def("_1pwnq79", "notebook_title", ["notebook_name","_runtime"], _1pwnq79);  
-  $def("_1xzlmfy", "utf8ToBase64", [], _1xzlmfy);  
+  $def("_433z46", "utf8ToBase64", [], _433z46);  
   $def("_14gyvdn", null, ["md"], _14gyvdn);  
   $def("_3dtu61", "TRACE_MODULE", [], _3dtu61);  
   $def("_g3fan0", null, ["task"], _g3fan0);  
   $def("_1km8e4e", "task_runtime", ["task"], _1km8e4e);  
   $def("_tdkfs5", "runtime_variables", ["task_runtime","variableToObject"], _tdkfs5);  
-  $def("_1thre44", "buildModuleNames", [], _1thre44);  
+  $def("_qc5kek", "buildModuleNames", [], _qc5kek);  
   $def("_1pfdk6e", "isModuleVar", [], _1pfdk6e);  
   $def("_1vua7u7", "isDynamicVar", [], _1vua7u7);  
-  $def("_13nx5f5", "isImportBridged", [], _13nx5f5);  
-  $def("_4l3h5t", "findImportedName3", [], _4l3h5t);  
-  $def("_1r5dbt4", "moduleNames", ["task","moduleMap","task_runtime"], _1r5dbt4);  
+  $def("_9cxfm9", "isImportBridged", [], _9cxfm9);  
+  $def("_1omyant", "findImportedName3", [], _1omyant);  
+  $def("_x9dxs8", "moduleNames", ["task","moduleMap","task_runtime"], _x9dxs8);  
   $def("_2o6tia", null, ["resolve_modules"], _2o6tia);  
   $def("_dx8tp1", null, ["summary"], _dx8tp1);  
-  $def("_rd2qwz", "excluded_module_names", [], _rd2qwz);  
+  $def("_ti9fu1", "excluded_module_names", [], _ti9fu1);  
   $def("_po3sop", "excluded_modules", ["moduleNames","excluded_module_names"], _po3sop);  
   $def("_16u7vne", "included_modules", ["moduleNames","excluded_module_names"], _16u7vne);  
-  $def("_1y5e5x8", "module_specs", ["task","included_modules","TRACE_MODULE","task_runtime","isModuleVar","isDynamicVar","getFileAttachments","main","generate_module_source","moduleNames"], _1y5e5x8);  
+  $def("_kxkh98", "module_specs", ["task","included_modules","TRACE_MODULE","task_runtime","isModuleVar","isDynamicVar","getFileAttachments","main","generate_module_source","moduleNames"], _kxkh98);  
   $def("_1r3eg9r", "findImports", [], _1r3eg9r);  
-  $def("_ipv4ft", "getFileAttachments", [], _ipv4ft);  
-  $def("_strmord", "streamingModuleOrder", [], _strmord);
-  $def("_fb2vp1", "book", ["task","inlineModule","inlineGzipModule","es_module_shims","runtime_gz","inspector_gz","module_specs","lopemodule","lopebook","streamingModuleOrder"], _fb2vp1);
-  $def("_18javdl", null, ["Inputs","module_specs"], _18javdl);  
-  $def("_1gb47v", null, ["md"], _1gb47v);  
-  $def("_5m8hbe", "report", ["DOMParser","book"], _5m8hbe);  
-  $def("_4x0qc2", "tomlarkworthy_exporter_task", ["book","report","exporter_module","viewof task"], _4x0qc2);  
-  $def("_1exq2jt", null, ["md"], _1exq2jt);  
-  $def("_fctoc0", null, ["md"], _fctoc0);  
-  $def("_85q15a", "exportModuleJS", ["_runtime","buildModuleNames","isModuleVar","isDynamicVar","getFileAttachments","generate_module_source"], _85q15a);  
+  $def("_15bukmh", "getFileAttachments", [], _15bukmh);  
+  $def("_g0wr2v", "streamingModuleOrder", [], _g0wr2v);  
+  $def("_e1usrg", "book", ["task","inlineModule","inlineGzipModule","es_module_shims","runtime_gz","inspector_gz","streamingModuleOrder","module_specs","lopemodule","lopebook"], _e1usrg);  
+  $def("_tztkf6", null, ["Inputs","module_specs"], _tztkf6);  
+  $def("_1razd4c", null, ["md"], _1razd4c);  
+  $def("_avn3ei", "report", ["DOMParser","book"], _avn3ei);  
+  $def("_186iat6", "tomlarkworthy_exporter_task", ["book","report","exporter_module","viewof task"], _186iat6);  
+  $def("_9aqzbs", null, ["md"], _9aqzbs);  
+  $def("_1h8zj4h", null, ["md"], _1h8zj4h);  
+  $def("_1xx9ynh", "exportModuleJS", ["_runtime","buildModuleNames","isModuleVar","isDynamicVar","getFileAttachments","generate_module_source"], _1xx9ynh);  
   $def("_udwrns", "generate_module_source", ["generate_definitions","generate_define"], _udwrns);  
   $def("_19ft5zb", "generate_definitions", ["variableToDefinition"], _19ft5zb);  
-  $def("_7nr512", "generate_define", ["variableToDefine"], _7nr512);  
+  $def("_u3aown", "generate_define", ["variableToDefine"], _u3aown);  
   $def("_1hslsmt", "isLiveImport", [], _1hslsmt);  
-  $def("_g39v22", "variableToDefinition", ["isModuleVar","isImportBridged","isLiveImport","isDynamicVar","pid","restoreCanonicalImports"], _g39v22);  
-  $def("_5zomoj", "restoreCanonicalImports", ["acorn","escodegen"], _5zomoj);  
-  $def("_1g36je3", "variableToDefine", ["isLiveImport","isDynamicVar","isModuleVar","isImportBridged","findImportedName3","pid"], _1g36je3);  
-  $def("_dxkjia", null, ["md"], _dxkjia);  
+  $def("_4i5mmq", "variableToDefinition", ["isModuleVar","isImportBridged","isLiveImport","isDynamicVar","pid","restoreCanonicalImports"], _4i5mmq);  
+  $def("_79c94t", "restoreCanonicalImports", ["acorn"], _79c94t);  
+  $def("_1g13ozv", "variableToDefine", ["isLiveImport","isDynamicVar","isModuleVar","isImportBridged","findImportedName3","pid"], _1g13ozv);  
+  $def("_8rymrb", null, ["md"], _8rymrb);  
   $def("_g33g3u", "es_module_shims", [], _g33g3u);  
   $def("_1na8qih", "inspector_gz", [], _1na8qih);  
   $def("_3naqgd", "inlineModule", [], _3naqgd);  
   $def("_19eucuj", "inlineGzipModule", [], _19eucuj);  
   $def("_bwex58", "normalize", [], _bwex58);  
-  $def("_eoywzy", "test_normalize", ["expect","normalize"], _eoywzy);
-  $def("_strmtest1", "test_networking_script_is_streaming", ["expect","networking_script"], _strmtest1);
-  $def("_strmtest2", "test_lopebook_main_at_top_with_sentinel", ["expect","lopebook"], _strmtest2);
-  $def("_strmtest3", "test_streaming_order_prioritizes_mains", ["expect","streamingModuleOrder"], _strmtest3);
-  $def("_strmtest4", "test_streaming_order_runtime", ["expect","Runtime","streamingModuleOrder"], _strmtest4);
+  $def("_1vymoni", "test_normalize", ["expect","normalize"], _1vymoni);  
+  $def("_158qnvp", "test_networking_script_is_streaming", ["networking_script","expect"], _158qnvp);  
+  $def("_1d9ux6v", "test_lopebook_main_at_top_with_sentinel", ["lopebook","expect"], _1d9ux6v);  
+  $def("_13d3rb0", "test_streaming_order_prioritizes_mains", ["expect","streamingModuleOrder"], _13d3rb0);  
+  $def("_18z61zg", "test_streaming_order_runtime", ["Runtime","streamingModuleOrder","expect"], _18z61zg);  
+  $def("_1didxs7", "test_restoreCanonicalImports", ["restoreCanonicalImports","expect"], _1didxs7);  
+  $def("_ogm44p", "test_restoreCanonicalImports_preserves_source", ["expect","restoreCanonicalImports"], _ogm44p);  
   $def("_1vgrzwk", "isNotebook", [], _1vgrzwk);  
-  $def("_1pcnq22", "networking_script", ["normalize","isNotebook"], _1pcnq22);  
-  $def("_lq8bhb", "lopebook", ["diskDataUrl","networking_script"], _lq8bhb);  
-  $def("_lzzjtg", "lopemodule", ["TRACE_MODULE","CSS","arrayBufferToBase64","inlineModule","escapeScriptTags"], _lzzjtg);  
+  $def("_1s9g3fb", "networking_script", ["normalize","isNotebook"], _1s9g3fb);  
+  $def("_kfs9ca", "lopebook", ["diskDataUrl","networking_script"], _kfs9ca);  
+  $def("_li7wcc", "lopemodule", ["TRACE_MODULE","CSS","arrayBufferToBase64","inlineModule","escapeScriptTags"], _li7wcc);  
   $def("_19l1umr", "escapeScriptTags", [], _19l1umr);  
-  $def("_1hwkszj", "arrayBufferToBase64", [], _1hwkszj);  
-  $def("_am38ex", null, ["md"], _am38ex);  
-  $def("_kx1h0y", null, ["md"], _kx1h0y);  
-  $def("_t237wb", "getCompactISODate", [], _t237wb);  
-  $def("_1nku2br", null, ["md"], _1nku2br);  
+  $def("_xpg7uv", "arrayBufferToBase64", [], _xpg7uv);  
+  $def("_1iz5onh", null, ["md"], _1iz5onh);  
+  $def("_b9np5w", null, ["md"], _b9np5w);  
+  $def("_fw7q7v", "getCompactISODate", [], _fw7q7v);  
+  $def("_7vqfq9", null, ["md"], _7vqfq9);  
   $def("_8765p8", "diskDataUrl", ["disk_svg"], _8765p8);  
   $def("_z4k2or", "viewof task", ["flowQueue"], _z4k2or);  
   $def("_ngmf1x", "task", ["Generators","viewof task"], _ngmf1x);  
@@ -2057,7 +2170,9 @@ export default function define(runtime, observer) {
   $def("_ei7ugd", "output", ["Generators","viewof output"], _ei7ugd);  
   $def("_blfbdd", "viewof exporter_module", ["thisModule"], _blfbdd);  
   $def("_1iao5e4", "exporter_module", ["Generators","viewof exporter_module"], _1iao5e4);  
+  main.define("linkTo", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("linkTo", _));  
   main.define("runtime_gz", ["module @tomlarkworthy/observable-runtime-v6", "@variable"], (_, v) => v.import("source_gz", "runtime_gz", _));  
+  main.define("Runtime", ["module @tomlarkworthy/observable-runtime-v6", "@variable"], (_, v) => v.import("Runtime", _));  
   main.define("flowQueue", ["module @tomlarkworthy/flow-queue", "@variable"], (_, v) => v.import("flowQueue", _));  
   main.define("cellMap", ["module @tomlarkworthy/cell-map", "@variable"], (_, v) => v.import("cellMap", _));  
   main.define("findModuleName", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("findModuleName", _));  
@@ -2067,11 +2182,9 @@ export default function define(runtime, observer) {
   main.define("parser", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("parser", _));  
   main.define("decompress_url", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("decompress_url", _));  
   main.define("acorn", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("acorn", _));  
-  main.define("escodegen", ["module @tomlarkworthy/observablejs-toolchain", "@variable"], (_, v) => v.import("escodegen", _));  
   main.define("view", ["module @tomlarkworthy/view", "@variable"], (_, v) => v.import("view", _));  
   main.define("variable", ["module @tomlarkworthy/view", "@variable"], (_, v) => v.import("variable", _));  
-  main.define("bindOneWay", ["module @tomlarkworthy/view", "@variable"], (_, v) => v.import("bindOneWay", _));
-  main.define("linkTo", ["module @tomlarkworthy/lopepage-urls", "@variable"], (_, v) => v.import("linkTo", _));
+  main.define("bindOneWay", ["module @tomlarkworthy/view", "@variable"], (_, v) => v.import("bindOneWay", _));  
   main.define("reversibleAttach", ["module @tomlarkworthy/reversible-attachment", "@variable"], (_, v) => v.import("reversibleAttach", _));  
   main.define("localStorageView", ["module @tomlarkworthy/local-storage-view", "@variable"], (_, v) => v.import("localStorageView", _));  
   main.define("domView", ["module @tomlarkworthy/dom-view", "@variable"], (_, v) => v.import("domView", _));  
@@ -2087,8 +2200,7 @@ export default function define(runtime, observer) {
   main.define("main", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("main", _));  
   main.define("id", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("id", _));  
   main.define("importShim", ["module @tomlarkworthy/runtime-sdk", "@variable"], (_, v) => v.import("importShim", _));  
-  main.define("expect", ["module @tomlarkworthy/jest-expect-standalone", "@variable"], (_, v) => v.import("expect", _));
-  main.define("Runtime", ["module @tomlarkworthy/observable-runtime-v6", "@variable"], (_, v) => v.import("Runtime", _));
+  main.define("expect", ["module @tomlarkworthy/jest-expect-standalone", "@variable"], (_, v) => v.import("expect", _));  
   main.define("themes", ["module @tomlarkworthy/themes", "@variable"], (_, v) => v.import("themes", _));  
   main.define("extra_css", ["module @tomlarkworthy/themes", "@variable"], (_, v) => v.import("extra_css", _));  
   main.define("current_theme", ["module @tomlarkworthy/themes", "@variable"], (_, v) => v.import("current_theme", _));  

--- a/modules/@tomlarkworthy/observablejs-toolchain.js
+++ b/modules/@tomlarkworthy/observablejs-toolchain.js
@@ -133,7 +133,7 @@ Promise.all(
     })
 )
 )};
-const _18xo2td = function _test_all_cells_roundtrippable(roundtripped)
+const _1shi9or = function _test_all_cells_roundtrippable(roundtripped)
 {
   const errored = roundtripped.filter((cell) => cell.error);
   if (errored.length > 0) throw JSON.stringify(errored, null, 2);
@@ -620,9 +620,9 @@ notebook_semantics_document.nodes.map((s) => ({
 const _1oevsow = function _28(md){return(
 md`### Runtime Representation (v4)`
 )};
-const _11lfflk = function _notebook_semantics_module() {
-    return import('https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4');
-};
+const _11lfflk = function _notebook_semantics_module(){return(
+import("https://api.observablehq.com/@tomlarkworthy/notebook-semantics.js?v=4")
+)};
 const _gjten6 = function _31(md){return(
 md`### Imports`
 )};
@@ -688,7 +688,7 @@ const _1v1d8m3 = async function _test_decompile_import_variable(decompile,import
   expect(decompiled).toEqual(`import {dep} from "@tomlarkworthy/dependancy"`);
   return "ok";
 };
-const _fiyb80 = async function _test_decompile_dollar_in_string_literal(decompile,expect)
+const _1ybjsqg = async function _test_decompile_dollar_in_string_literal(decompile,expect)
 {
   // Regression: $N inside a string/regex/template literal must NOT be substituted
   // with `viewof X` / `mutable X`. This is the cc_ws bug — regex backref $1
@@ -832,7 +832,7 @@ const _v4p1js = async function _test_decompile_constant(decompile,expect)
   expect(decompiled).toEqual(`v = 1`);
   return "ok";
 };
-const _pcs4h = async function _test_decompile_string_literal(decompile,expect)
+const _1puzspw = async function _test_decompile_string_literal(decompile,expect)
 {
   const decompiled = await decompile([
     {
@@ -858,7 +858,7 @@ const _a2zh99 = async function _test_decompile_html_cell(decompile,expect)
   expect(decompiled).toEqual(`html = htl.html\`<div>\``);
   return "ok";
 };
-const _pyp280 = async function _test_decompile_class(decompile,expect)
+const _1pt67ao = async function _test_decompile_class(decompile,expect)
 {
   const decompiled = await decompile([
     {
@@ -896,66 +896,6 @@ const _4vunhm = async function _test_decompile_object_literal(decompile,expect)
   expect(decompiled).toEqual(`obj_literal = ({})`);
   return "ok";
 };
-const _tstlc1 = async function _test_decompile_leading_comment(compile,decompile,expect)
-{
-  // Regression: a comment in the compiler's auto-wrap slot (`return( // note\n42 )`)
-  // is preserved in ASI-safe block form — never the hazardous `return` + comment
-  // + newline WITHOUT the paren that evaluated to undefined on ObservableHQ.
-  const src = await decompile([
-    { _name: "c", _definition: `function _c(){return( // note\n42\n)}`, _inputs: [] }
-  ]);
-  expect(src).toEqual(`c = {return( // note\n42\n)}`);
-  // It keeps the ASI-protecting paren and round-trips through compile to 42.
-  const cell = compile(src);
-  const first = Array.isArray(cell) ? cell[0] : cell;
-  const def = first._definition || (first.cells && first.cells[0]._definition);
-  expect(eval(`(${def})`)()).toEqual(42);
-  return "ok";
-};
-const _tsttc1 = async function _test_decompile_trailing_comment(decompile,expect)
-{
-  // Regression: a comment that survives compile inside the block (trailing on the
-  // return line, or before the closing brace) must survive decompile too — don't
-  // unwrap a single-return block when a comment sits outside the returned value.
-  const trailing = await decompile([
-    { _name: "x", _definition: `function _x(){\n  return 1; // done\n}`, _inputs: [] }
-  ]);
-  expect(trailing).toEqual(`x = {\n  return 1; // done\n}`);
-  const tail = await decompile([
-    { _name: "y", _definition: `function _y(){\n  return 1;\n  // tail\n}`, _inputs: [] }
-  ]);
-  expect(tail).toEqual(`y = {\n  return 1;\n  // tail\n}`);
-  return "ok";
-};
-const _tstpis = async function _test_decompile_param_in_string(decompile,expect)
-{
-  // Regression: renaming an underscore-encoded viewof/mutable param must rewrite
-  // only identifier references, never same-spelled text inside a string literal
-  // (range-based splice, not the old source.replaceAll).
-  const decompiled = await decompile([
-    {
-      _name: "u",
-      _definition: `function _u(viewof_x){return(\n"viewof_x literal" + viewof_x\n)}`,
-      _inputs: ["viewof x"]
-    }
-  ]);
-  expect(decompiled).toEqual(`u = "viewof_x literal" + viewof x`);
-  return "ok";
-};
-const _tstcpf = async function _test_decompile_class_property_field(decompile,expect)
-{
-  // Regression: a class field declaration must decompile cleanly. Source-slicing
-  // sidesteps the escodegen shim gap that threw "this[d] is not a function".
-  const decompiled = await decompile([
-    {
-      _name: "Cls",
-      _definition: `function _Cls(){return(\nclass Cls {\n  d;\n}\n)}`,
-      _inputs: []
-    }
-  ]);
-  expect(decompiled).toEqual(`Cls = class Cls {\n  d;\n}`);
-  return "ok";
-};
 const _s14e29 = async function _test_decompile_reference(decompile,expect)
 {
   const decompiled = await decompile([
@@ -970,7 +910,7 @@ x
   expect(decompiled).toEqual(`v = x`);
   return "ok";
 };
-const _4rsshj = async function _test_decompile_block(decompile,expect)
+const _14nvmno = async function _test_decompile_block(decompile,expect)
 {
   const decompiled = await decompile([
     {
@@ -989,7 +929,7 @@ const _4rsshj = async function _test_decompile_block(decompile,expect)
 }`);
   return "ok";
 };
-const _o7o1wl = async function _test_decompile_comments(decompile,expect)
+const _5kd9if = async function _test_decompile_comments(decompile,expect)
 {
   const decompiled = await decompile([
     {
@@ -1025,7 +965,7 @@ const _1yn35e3 = async function _test_decompile_generator(decompile,expect)
 }`);
   return "ok";
 };
-const _135eswd = async function _test_decompile_function(decompile,expect)
+const _10wf7cf = async function _test_decompile_function(decompile,expect)
 {
   const decompiled = await decompile([
     {
@@ -1039,7 +979,7 @@ function () {}
   expect(decompiled).toEqual(`_function = function () {}`);
   return "ok";
 };
-const _1pitq2 = async function _test_decompile_async_function(decompile,expect)
+const _1191zxm = async function _test_decompile_async_function(decompile,expect)
 {
   const decompiled = await decompile([
     {
@@ -1053,7 +993,7 @@ async function () {}
   expect(decompiled).toEqual(`asyncfunction = async function () {}`);
   return "ok";
 };
-const _1kxe1b2 = async function _test_decompile_named_function(decompile,expect)
+const _vpu09i = async function _test_decompile_named_function(decompile,expect)
 {
   const decompiled = await decompile([
     {
@@ -1081,7 +1021,7 @@ const _1pghf4f = async function _test_decompile_this_reference(decompile,expect)
   expect(decompiled).toEqual(`thisReference = (this || 0) + 1`);
   return "ok";
 };
-const _4aeghn = async function _test_decompile_lambda(decompile,expect)
+const _rajn7p = async function _test_decompile_lambda(decompile,expect)
 {
   const decompiled = await decompile([
     {
@@ -1112,7 +1052,7 @@ const _12ec5zd = async function _test_decompile_error(decompile,expect)
 }`);
   return "ok";
 };
-const _3bj09h = async function _test_decompile_error_object(decompile,expect)
+const _1c93ef9 = async function _test_decompile_error_object(decompile,expect)
 {
   const decompiled = await decompile([
     {
@@ -1187,7 +1127,7 @@ _
   expect(decompiled).toEqual(`inbuilt = _`);
   return "ok";
 };
-const _1uv76xx = async function _test_decompile_fileattachment(decompile,expect)
+const _4z1dnp = async function _test_decompile_fileattachment(decompile,expect)
 {
   const decompiled = await decompile([
     {
@@ -1271,7 +1211,7 @@ view
   expect(decompiled).toEqual(`viewofdatadep = view`);
   return "ok";
 };
-const _ehz2xk = async function _test_decompile_viewof_param(decompile,expect)
+const _b0y8zg = async function _test_decompile_viewof_param(decompile,expect)
 {
   // Lopecode compiled form uses viewof_X as parameter name instead of $N
   const decompiled = await decompile([
@@ -1304,7 +1244,7 @@ dep
   expect(decompiled).toEqual(`dep`);
   return "ok";
 };
-const _1jggajo = async function _test_decompile_import_mutable(decompile,expect)
+const _1eqf4jq = async function _test_decompile_import_mutable(decompile,expect)
 {
   const decompiled = await decompile([
     {
@@ -1318,7 +1258,7 @@ const _1jggajo = async function _test_decompile_import_mutable(decompile,expect)
   );
   return "ok";
 };
-const _di0abi = async function _test_decompile_import_viewof(decompile,expect)
+const _3damo4 = async function _test_decompile_import_viewof(decompile,expect)
 {
   const decompiled = await decompile([
     {
@@ -1330,7 +1270,7 @@ const _di0abi = async function _test_decompile_import_viewof(decompile,expect)
   expect(decompiled).toEqual(`viewof viewdep = v.import("viewof viewdep", _)`);
   return "ok";
 };
-const _14o5oio = async function _test_decompile_viewof_data(decompile,expect)
+const _1l9xqsw = async function _test_decompile_viewof_data(decompile,expect)
 {
   const decompiled = await decompile([
     {
@@ -1342,7 +1282,7 @@ const _14o5oio = async function _test_decompile_viewof_data(decompile,expect)
   expect(decompiled).toEqual(`viewdep = v.import("viewdep", _)`);
   return "ok";
 };
-const _1lv4syw = async function _test_decompile_import_alias(decompile,expect)
+const _1cggvdk = async function _test_decompile_import_alias(decompile,expect)
 {
   const decompiled = await decompile([
     {
@@ -1354,7 +1294,7 @@ const _1lv4syw = async function _test_decompile_import_alias(decompile,expect)
   expect(decompiled).toEqual(`dep_alias = v.import("dep", "dep_alias", _)`);
   return "ok";
 };
-const _l8b8hu = async function _test_decompile_import_mutable_alias(decompile,expect)
+const _xcwq4 = async function _test_decompile_import_mutable_alias(decompile,expect)
 {
   const decompiled = await decompile([
     {
@@ -1368,7 +1308,7 @@ const _l8b8hu = async function _test_decompile_import_mutable_alias(decompile,ex
   );
   return "ok";
 };
-const _1g5n3sa = async function _test_decompile_import_mutable_data_alias(decompile,expect)
+const _1868h0w = async function _test_decompile_import_mutable_data_alias(decompile,expect)
 {
   const decompiled = await decompile([
     {
@@ -1382,7 +1322,7 @@ const _1g5n3sa = async function _test_decompile_import_mutable_data_alias(decomp
   );
   return "ok";
 };
-const _1lnngk6 = async function _test_decompile_import_viewof_alias(decompile,expect)
+const _1afcxhk = async function _test_decompile_import_viewof_alias(decompile,expect)
 {
   const decompiled = await decompile([
     {
@@ -1396,7 +1336,7 @@ const _1lnngk6 = async function _test_decompile_import_viewof_alias(decompile,ex
   );
   return "ok";
 };
-const _1na1e5i = async function _test_decompile_import_viewof_data_alias(decompile,expect)
+const _1sl510 = async function _test_decompile_import_viewof_data_alias(decompile,expect)
 {
   const decompiled = await decompile([
     {
@@ -1413,24 +1353,11 @@ const _1na1e5i = async function _test_decompile_import_viewof_data_alias(decompi
 const _17dwb6r = function _80(md){return(
 md`### The Decompiler`
 )};
-const _1vs6mei = function _82(md){return(
+const _1ngipml = function _81(md){return(
 md`### \`decompile\``
 )};
-const _1g89k6a = function _escodegenOptions(escodegen){return(
-{
-  comment: true,
-  format: {
-    ...escodegen.FORMAT_DEFAULTS,
-    indent: {
-      ...escodegen.FORMAT_DEFAULTS.indent,
-      style: "  "
-    }
-  }
-}
-)};
-const _llvq9s = function _decompile(decompileImport,formatImportDeclaration,acorn,escodegen,escodegenOptions)
-{
-  return async function decompile(variables) {
+const _2d5g1 = function _decompile(decompileImport,formatImportDeclaration,acorn){return(
+async function decompile(variables) {
     if (!variables || variables.length === 0)
       throw new Error("no variables to decompile");
     const importInfo = await decompileImport(variables);
@@ -1600,9 +1527,9 @@ const _llvq9s = function _decompile(decompileImport,formatImportDeclaration,acor
 
     const source = `${varName ? `${prefix}${varName} = ` : ""}${expression}`;
     return source;
-  };
-};
-const _1pvis67 = function _85(md){return(
+  }
+)};
+const _1x0pvrl = function _83(md){return(
 md`### \`extractModuleInfo\` 
 static analysis of module imports`
 )};
@@ -1693,7 +1620,7 @@ const _iigmyv = function _test_extractModuleInfo_alias_hack(expect,extractModule
   });
   return "ok";
 };
-const _1tggbee = function _92(md){return(
+const _7t42k8 = function _90(md){return(
 md`### \`findModuleName\` and \`findImportedName\``
 )};
 const _kiaw33 = function _import_ast_example(parser){return(
@@ -1701,44 +1628,65 @@ parser.parseCell(
   'import {runtime, viewof main as foo} from "@mootari/access-runtime"'
 )
 )};
-const _1n7gw17 = function _findModuleName(extractModuleInfo) {
-    return (scope, module, {
-        unknown_id = Math.random()
-    } = {}) => {
-        try {
-            const scopedVariables = [...scope.values()];
-            const candidates = scopedVariables.filter(v => v && v._value === module && typeof v._name === 'string' && v._name.startsWith('module ') && !v._name.startsWith('module <unknown'));
-            const pickBestInfo = dfn => {
-                const s = String(dfn ?? '');
-                const m = s.match(/\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/);
-                const firstArg = m?.[2];
-                const info1 = firstArg ? extractModuleInfo(firstArg) : {};
-                if (info1?.id || info1?.notebook)
-                    return info1;
-                return extractModuleInfo(s);
-            };
-            for (const v of candidates) {
-                const info = pickBestInfo(v._definition?.toString?.());
-                if (info?.namespace)
-                    return `@${ info.namespace }/${ info.notebook }`;
-                if (info?.id)
-                    return `d/${ info.id }@${ info.version }`;
-            }
-            const any = scopedVariables.find(v => v && v._value === module);
-            if (any) {
-                const info = pickBestInfo(any._definition?.toString?.());
-                if (info?.namespace)
-                    return `@${ info.namespace }/${ info.notebook }`;
-                if (info?.id)
-                    return `d/${ info.id }@${ info.version }`;
-            }
-            return `<unknown ${ unknown_id }>`;
-        } catch (e) {
-            void 0;
-            return 'error';
-        }
+const _1n7gw17 = function _findModuleName(extractModuleInfo){return(
+(scope, module, { unknown_id = Math.random() } = {}) => {
+  try {
+    const scopedVariables = [...scope.values()];
+
+    // Prefer variables that *define* a module and have a real module-loader name.
+    const candidates = scopedVariables.filter(
+      (v) =>
+        v &&
+        v._value === module &&
+        typeof v._name === "string" &&
+        v._name.startsWith("module ") &&
+        !v._name.startsWith("module <unknown")
+    );
+
+    const pickBestInfo = (dfn) => {
+      // Avoid the parentUrl (2nd arg) confusing module identification.
+      // Typical patterns:
+      //   importShim("/d/<id>@<ver>.js?v=4", "https://api.observablehq.com/@ns/name.js?v=4")
+      //   import("/d/<id>@<ver>.js?v=4")
+      // Prefer the *first argument* inside importShim(...) / import(...) when present.
+      const s = String(dfn ?? "");
+
+      // Try to capture the first string literal argument to importShim(...) or import(...)
+      // Tolerates quotes ", ', ` and both importShim and plain import.
+      const m = s.match(
+        /\bimport(?:Shim)?\(\s*(["'`])((?:\\.|(?!\1)[\s\S])*)\1/
+      );
+      const firstArg = m?.[2];
+
+      const info1 = firstArg ? extractModuleInfo(firstArg) : {};
+      if (info1?.id || info1?.notebook) return info1;
+
+      // Fallback: parse the whole definition string.
+      return extractModuleInfo(s);
     };
-};
+
+    // Try module loader cells first.
+    for (const v of candidates) {
+      const info = pickBestInfo(v._definition?.toString?.());
+      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
+      if (info?.id) return `d/${info.id}@${info.version}`;
+    }
+
+    // Fallback: any scoped variable with _value==module.
+    const any = scopedVariables.find((v) => v && v._value === module);
+    if (any) {
+      const info = pickBestInfo(any._definition?.toString?.());
+      if (info?.namespace) return `@${info.namespace}/${info.notebook}`;
+      if (info?.id) return `d/${info.id}@${info.version}`;
+    }
+
+    return `<unknown ${unknown_id}>`;
+  } catch (e) {
+    debugger;
+    return "error";
+  }
+}
+)};
 const _i47chb = function _findImportedName(){return(
 async (v) => {
   if (v._inputs.length == 1 && v._inputs[0]._name === "@variable") {
@@ -1759,10 +1707,10 @@ async (v) => {
   return v._name;
 }
 )};
-const _1effqg = function _96(md){return(
+const _ed3cy2 = function _94(md){return(
 md`### \`decompileImport\``
 )};
-const _b7vai6 = function _decompileImport(findModuleName,findImportedName)
+const _1a4j4gm = function _decompileImport(findModuleName,findImportedName)
 {
   return async function decompileImport(variables, options = {}) {
     if (!variables || variables.length === 0)
@@ -1801,7 +1749,7 @@ const _b7vai6 = function _decompileImport(findModuleName,findImportedName)
       if (!Array.isArray(inputs) || inputs.length !== 2)
         return false;
       const [i0, i1] = inputs;
-      return !!(i0 && typeof i0 === 'object' && typeof i0._name === 'string' && i0._name.startsWith('module @') && i1 && typeof i1 === 'object' && i1._name === '@variable');
+      return !!(i0 && typeof i0 === 'object' && typeof i0._name === 'string' && i0._name.startsWith('module ') && i1 && typeof i1 === 'object' && i1._name === '@variable');
     };
     const isStageC = v => {
       const inputs = v?._inputs;
@@ -1934,32 +1882,8 @@ const _1u6sfri = async function _test_decompileImport_alias(importFake,decompile
 
   return "ok";
 };
-const _1lqhutp = function _102(md){return(
+const _1lti0tv = function _100(md){return(
 md`## Javascript Source Normalization`
-)};
-const _ikzxev = function _normalizeJavascriptSource(acorn,escodegen){return(
-(source) => {
-  var comments = [];
-  var tokens = [];
-
-  var ast = acorn.parse(source, {
-    ranges: true,
-    onComment: comments,
-    onToken: tokens
-  });
-
-  escodegen.attachComments(ast, comments, tokens);
-  return escodegen.generate(ast, {
-    comment: true
-  });
-}
-)};
-const _az8lo6 = function _normalizeVariables(variableToObject,normalizeJavascriptSource){return(
-(variables) =>
-  variables.map(variableToObject).map((v) => ({
-    ...v,
-    _definition: normalizeJavascriptSource(v._definition)
-  }))
 )};
 const _3knb9v = function _variableToObject(){return(
 (v) => ({
@@ -1968,7 +1892,7 @@ const _3knb9v = function _variableToObject(){return(
   _inputs: v._inputs.map((v) => v._name || v)
 })
 )};
-const _263fcv = function _106(md){return(
+const _autn1v = function _102(md){return(
 md`## Observable Source Normalization`
 )};
 const _7zpsl9 = function _normalizeObservableSourceSelector(Inputs,notebook_semantics_source){return(
@@ -1978,94 +1902,10 @@ Inputs.select(
 )
 )};
 const _1ex8kus = (G, _) => G.input(_);
-const _17petbz = function _108(normalizeObservableSource,normalizeObservableSourceSelector){return(
-normalizeObservableSource(normalizeObservableSourceSelector)
-)};
 const _b2d0zc = function _parsed(parser,normalizeObservableSourceSelector){return(
 parser.parseCell(normalizeObservableSourceSelector)
 )};
-const _qtgjo9 = function _generate(escodegen){return(
-function generate(node, source) {
-  if (node.type == "Cell") {
-    if (
-      node.body.type != "BlockStatement" &&
-      source &&
-      source[node.body.start] == "{"
-    ) {
-      return `${node.id ? `${generate(node.id)} = ` : ""}(${escodegen.generate(
-        node.body
-      )})`;
-    } else {
-      return `${node.id ? `${generate(node.id)} = ` : ""}${escodegen.generate(
-        node.body
-      )}`;
-    }
-  } else if (node.type == "Identifier") {
-    return escodegen.generate(node);
-  } else if (node.type == "ViewExpression") {
-  } else {
-    throw node.type;
-  }
-}
-)};
-const _104j23i = function _normalizeObservableSource(parser,generate){return(
-{
-  prompt:
-    'I see some of the test are failing because the AST generator uses a different set of quotes than the original source and various formatting quirks. This should not count as failure. I would suggest normalizing. Its not super easy because source code is not vanilla JS, we need to normalize just the bit after the block expression, and replace the "viewof XX" and "mutable XXX" macros with a placeholder whic we can normalize and then undo. Write the normalizeObservableSource.',
-  time: 1729097489369
-} &&
-  function normalizeObservableSource(source) {
-    // Replace viewof and mutable with placeholders
-    const viewofRegex = /viewof\s+([a-zA-Z_][a-zA-Z0-9_]*)/g;
-    const mutableRegex = /mutable\s+([a-zA-Z_][a-zA-Z0-9_]*)/g;
-
-    // Temporary placeholders
-    const VIEWOF_PLACEHOLDER = "__VIEWOF_PLACEHOLDER__";
-    const MUTABLE_PLACEHOLDER = "__MUTABLE_PLACEHOLDER__";
-
-    // Maps to store original names
-    const viewOfMap = new Map();
-    const mutableMap = new Map();
-
-    // Replace viewof XX with placeholder and store mapping
-    source = source.replace(viewofRegex, (match, p1) => {
-      const placeholder = `${VIEWOF_PLACEHOLDER}_${p1}`;
-      viewOfMap.set(placeholder, p1);
-      return placeholder;
-    });
-
-    // Replace mutable XXX with placeholder and store mapping
-    source = source.replace(mutableRegex, (match, p1) => {
-      const placeholder = `${MUTABLE_PLACEHOLDER}_${p1}`;
-      mutableMap.set(placeholder, p1);
-      return placeholder;
-    });
-
-    // Normalize quotes: convert all to single quotes
-    const comments = [],
-      tokens = [];
-    const cell = parser.parseCell(source, {
-      ranges: true,
-      onComment: comments,
-      onToken: tokens
-    });
-    
-
-    source = generate(cell, source);
-
-    // Restore original viewof and mutable identifiers
-    viewOfMap.forEach((original, placeholder) => {
-      source = source.replaceAll(placeholder, `viewof ${original}`);
-    });
-
-    mutableMap.forEach((original, placeholder) => {
-      source = source.replaceAll(placeholder, `mutable ${original}`);
-    });
-
-    return source;
-  }
-)};
-const _vle3wv = function _112(md){return(
+const _14qm8or = function _105(md){return(
 md`## The Compiler
 
 `
@@ -2133,7 +1973,7 @@ const _x7zc8w = async function _test_compile_integer(compile,expect)
   ]);
   return "ok";
 };
-const _1u7hlem = async function _test_compile_string(compile,expect)
+const _1qp2ggw = async function _test_compile_string(compile,expect)
 {
   const compiled = await compile(`""`);
   expect(compiled).toEqual([
@@ -2157,15 +1997,7 @@ const _151bijp = async function _test_compile_obj_literal(compile,expect)
   ]);
   return "ok";
 };
-const _tstcff = async function _test_compile_preserves_formatting(compile,expect)
-{
-  // Source-preserving compile keeps quote style and template spacing verbatim;
-  // escodegen used to re-quote ("h1" -> 'h1') and respace (${s} -> ${ s }).
-  const compiled = await compile('x = { const s = "h1"; return `${s}`; }');
-  expect(compiled[0]._definition).toEqual('function _x() { const s = "h1"; return `${s}`; }');
-  return "ok";
-};
-const _ti9okn = async function _test_compile_assignment(compile,expect)
+const _17z4vyt = async function _test_compile_assignment(compile,expect)
 {
   const compiled = await compile(`x = ""`);
   expect(compiled).toEqual([
@@ -2189,7 +2021,7 @@ const _1eb8vq = async function _test_compile_dependancy(compile,expect)
   ]);
   return "ok";
 };
-const _acs4l0 = async function _test_compile_block_dependancy(compile,expect)
+const _5b8x33 = async function _test_compile_block_dependancy(compile,expect)
 {
   const compiled = await compile(`z = {
   ("");
@@ -2204,7 +2036,7 @@ const _acs4l0 = async function _test_compile_block_dependancy(compile,expect)
   ]);
   return "ok";
 };
-const _125ljg9 = async function _test_compile_comments(compile,expect)
+const _9s1umz = async function _test_compile_comments(compile,expect)
 {
   const compiled = await compile(`comments = {
   // a comment
@@ -2219,7 +2051,7 @@ const _125ljg9 = async function _test_compile_comments(compile,expect)
   ]);
   return "ok";
 };
-const _li37je = async function _test_compile_generator(compile,expect)
+const _1rbs7b6 = async function _test_compile_generator(compile,expect)
 {
   const compiled = await compile(`generator = {
   yield x + y;
@@ -2233,7 +2065,7 @@ const _li37je = async function _test_compile_generator(compile,expect)
   ]);
   return "ok";
 };
-const _em4em6 = async function _test_compile_function(compile,expect)
+const _1gaxmhs = async function _test_compile_function(compile,expect)
 {
   const compiled = await compile(`_function = function () {}`);
   expect(compiled).toEqual([
@@ -2245,7 +2077,7 @@ const _em4em6 = async function _test_compile_function(compile,expect)
   ]);
   return "ok";
 };
-const _w3atfb = async function _test_compile_async_function(compile,expect)
+const _2ozyn1 = async function _test_compile_async_function(compile,expect)
 {
   const compiled = await compile(`asyncfunction = async function () {}`);
   expect(compiled).toEqual([
@@ -2258,7 +2090,7 @@ const _w3atfb = async function _test_compile_async_function(compile,expect)
   ]);
   return "ok";
 };
-const _14gl6yr = async function _test_compile_named_function(compile,expect)
+const _1jn3lk9 = async function _test_compile_named_function(compile,expect)
 {
   const compiled = await compile(`named_function = function foo() {}`);
   expect(compiled).toEqual([
@@ -2282,7 +2114,7 @@ const _z3bqb8 = async function _test_compile_this_reference(compile,expect)
   ]);
   return "ok";
 };
-const _1sou7t0 = async function _test_compile_lambda(compile,expect)
+const _1lyze5m = async function _test_compile_lambda(compile,expect)
 {
   const compiled = await compile(`lambda = () => {}`);
   expect(compiled).toEqual([
@@ -2294,7 +2126,7 @@ const _1sou7t0 = async function _test_compile_lambda(compile,expect)
   ]);
   return "ok";
 };
-const _1o1u737 = async function _test_compile_error(compile,expect)
+const _12k1xub = async function _test_compile_error(compile,expect)
 {
   const compiled = await compile(`error = {
   throw new Error();
@@ -2381,7 +2213,7 @@ const _78egw8 = async function _test_compile_builtin(compile,expect)
   ]);
   return "ok";
 };
-const _lflzev = async function _test_compile_fileattachment(compile,expect)
+const _1o65727 = async function _test_compile_fileattachment(compile,expect)
 {
   const compiled = await compile(`file = FileAttachment("empty")`);
   expect(compiled).toEqual([
@@ -2394,7 +2226,7 @@ const _lflzev = async function _test_compile_fileattachment(compile,expect)
   ]);
   return "ok";
 };
-const _1e555b1 = async function _test_compile_mutable_dep(compile,expect)
+const _14c9yxp = async function _test_compile_mutable_dep(compile,expect)
 {
   const compiled = await compile(`mutable_dep = {
   viewof view;
@@ -2412,7 +2244,7 @@ const _1e555b1 = async function _test_compile_mutable_dep(compile,expect)
   ]);
   return "ok";
 };
-const _1a2af6 = async function _test_compile_mutable_dep2(compile,expect)
+const _133w84q = async function _test_compile_mutable_dep2(compile,expect)
 {
   const compiled = await compile(`mutable_dep_2 = {
   file;
@@ -2464,7 +2296,7 @@ const _1y1h47u = async function _test_compile_dep(compile,expect)
   ]);
   return "ok";
 };
-const _kwdsyz = async function _test_compile_class(compile,expect)
+const _1r711sh = async function _test_compile_class(compile,expect)
 {
   const compiled = await compile(`v = class {}`);
   expect(compiled).toEqual([
@@ -2512,7 +2344,7 @@ Inputs.textarea({
   label: "compile test template"
 })
 )};
-const _1lmax86 = async function _test_compile_import_plain_single(compile,expect)
+const _1vg114c = async function _test_compile_import_plain_single(compile,expect)
 {
   const compiled = await compile(
     `import {dep} from "@tomlarkworthy/dependancy";`
@@ -2521,7 +2353,7 @@ const _1lmax86 = async function _test_compile_import_plain_single(compile,expect
     {
       _name: "module @tomlarkworthy/dependancy",
       _inputs: [],
-      _definition: `async () => runtime.module((await import("@tomlarkworthy/dependancy")).default)`
+      _definition: `async () => runtime.module((await import("/@tomlarkworthy/dependancy.js?v=4")).default)`
     },
     {
       _name: "dep",
@@ -2531,7 +2363,7 @@ const _1lmax86 = async function _test_compile_import_plain_single(compile,expect
   ]);
   return "ok";
 };
-const _17sgzdm = async function _test_compile_import_view_data_alias_single(compile,expect)
+const _18h6y38 = async function _test_compile_import_view_data_alias_single(compile,expect)
 {
   const compiled = await compile(
     `import {viewdep as aslias_viewdep_data} from "@tomlarkworthy/dependancy";`
@@ -2540,7 +2372,7 @@ const _17sgzdm = async function _test_compile_import_view_data_alias_single(comp
     {
       _name: "module @tomlarkworthy/dependancy",
       _inputs: [],
-      _definition: `async () => runtime.module((await import("@tomlarkworthy/dependancy")).default)`
+      _definition: `async () => runtime.module((await import("/@tomlarkworthy/dependancy.js?v=4")).default)`
     },
     {
       _name: "aslias_viewdep_data",
@@ -2550,7 +2382,7 @@ const _17sgzdm = async function _test_compile_import_view_data_alias_single(comp
   ]);
   return "ok";
 };
-const _1tqj4tp = async function _test_compile_import_mutable_data_alias_single(compile,expect)
+const _1svcdun = async function _test_compile_import_mutable_data_alias_single(compile,expect)
 {
   const compiled = await compile(
     `import {mutabledep as aslias_mutabledep_data} from "@tomlarkworthy/dependancy";`
@@ -2559,7 +2391,7 @@ const _1tqj4tp = async function _test_compile_import_mutable_data_alias_single(c
     {
       _name: "module @tomlarkworthy/dependancy",
       _inputs: [],
-      _definition: `async () => runtime.module((await import("@tomlarkworthy/dependancy")).default)`
+      _definition: `async () => runtime.module((await import("/@tomlarkworthy/dependancy.js?v=4")).default)`
     },
     {
       _name: "aslias_mutabledep_data",
@@ -2569,7 +2401,7 @@ const _1tqj4tp = async function _test_compile_import_mutable_data_alias_single(c
   ]);
   return "ok";
 };
-const _hv0te2 = async function _test_compile_import_mutable_single(compile,expect)
+const _tb4ops = async function _test_compile_import_mutable_single(compile,expect)
 {
   const compiled = await compile(
     `import {mutable mutabledep} from "@tomlarkworthy/dependancy";`
@@ -2578,7 +2410,7 @@ const _hv0te2 = async function _test_compile_import_mutable_single(compile,expec
     {
       _name: "module @tomlarkworthy/dependancy",
       _inputs: [],
-      _definition: `async () => runtime.module((await import("@tomlarkworthy/dependancy")).default)`
+      _definition: `async () => runtime.module((await import("/@tomlarkworthy/dependancy.js?v=4")).default)`
     },
     {
       _name: "mutable mutabledep",
@@ -2588,7 +2420,7 @@ const _hv0te2 = async function _test_compile_import_mutable_single(compile,expec
   ]);
   return "ok";
 };
-const _1mltqmr = async function _test_compile_import_viewof_single(compile,expect)
+const _vuzib9 = async function _test_compile_import_viewof_single(compile,expect)
 {
   const compiled = await compile(
     `import {viewof viewdep} from "@tomlarkworthy/dependancy";`
@@ -2597,7 +2429,7 @@ const _1mltqmr = async function _test_compile_import_viewof_single(compile,expec
     {
       _name: "module @tomlarkworthy/dependancy",
       _inputs: [],
-      _definition: `async () => runtime.module((await import("@tomlarkworthy/dependancy")).default)`
+      _definition: `async () => runtime.module((await import("/@tomlarkworthy/dependancy.js?v=4")).default)`
     },
     {
       _name: "viewof viewdep",
@@ -2607,7 +2439,7 @@ const _1mltqmr = async function _test_compile_import_viewof_single(compile,expec
   ]);
   return "ok";
 };
-const _1d18obr = async function _test_compile_import_alias_single(compile,expect)
+const _6ewshd = async function _test_compile_import_alias_single(compile,expect)
 {
   const compiled = await compile(
     `import {dep as dep_alias} from "@tomlarkworthy/dependancy";`
@@ -2616,7 +2448,7 @@ const _1d18obr = async function _test_compile_import_alias_single(compile,expect
     {
       _name: "module @tomlarkworthy/dependancy",
       _inputs: [],
-      _definition: `async () => runtime.module((await import("@tomlarkworthy/dependancy")).default)`
+      _definition: `async () => runtime.module((await import("/@tomlarkworthy/dependancy.js?v=4")).default)`
     },
     {
       _name: "dep_alias",
@@ -2626,7 +2458,7 @@ const _1d18obr = async function _test_compile_import_alias_single(compile,expect
   ]);
   return "ok";
 };
-const _1b5ghef = async function _test_compile_import_notebook(compile,expect)
+const _36migr = async function _test_compile_import_notebook(compile,expect)
 {
   const compiled = await compile(
     `import {escodegen} from "@tomlarkworthy/escodegen"`
@@ -2636,7 +2468,7 @@ const _1b5ghef = async function _test_compile_import_notebook(compile,expect)
       _name: `module @tomlarkworthy/escodegen`,
       _inputs: [],
       _definition:
-        'async () => runtime.module((await import("@tomlarkworthy/escodegen")).default)'
+        'async () => runtime.module((await import("/@tomlarkworthy/escodegen.js?v=4")).default)'
     },
     {
       _name: `escodegen`,
@@ -2656,13 +2488,13 @@ Inputs.select(
 )
 )};
 const _1e5ax6f = (G, _) => G.input(_);
-const _18e5b93 = function _153(test_case){return(
+const _7eic89 = function _146(test_case){return(
 test_case.value
 )};
 const _16q6oyc = async function _compiled(compile,test_case){return(
 await compile(test_case.value)
 )};
-const _1191170 = function _155(parser,test_case)
+const _61dayu = function _148(parser,test_case)
 {
   const comments = [];
   const tokens = [];
@@ -2678,27 +2510,10 @@ const _1191170 = function _155(parser,test_case)
     tokens
   };
 };
-const _1gh543z = function _compiled_selector(Inputs,compiled){return(
-Inputs.radio(compiled, {
-  format: (v) => v._name,
-  value: compiled[0]
-})
-)};
-const _1dmmuaf = (G, _) => G.input(_);
-const _1klx74n = function _157(compiled_selector,normalizeJavascriptSource){return(
-JSON.stringify(
-  {
-    ...compiled_selector,
-    _definition: normalizeJavascriptSource(compiled_selector._definition)
-  },
-  null,
-  2
-)
-)};
-const _eom91x = function _158(compile,test_case){return(
+const _cevs6r = function _149(compile,test_case){return(
 compile(test_case.value)
 )};
-const _ttos3c = function _compile(parser,observableToJs){return(
+const _mliwy8 = function _compile(parser,observableToJs){return(
 function compile(source, {
   anonymousName = '_anonymous'
 } = {}) {
@@ -2900,7 +2715,7 @@ function compile(source, {
   });
 }
 )};
-const _1v1i7wl = function _observableToJs(acorn_walk,parser){return(
+const _16p8atj = function _observableToJs(acorn_walk,parser){return(
 (ast, inputMap, source) => {
   // Source-preserving: slice the original body text verbatim and splice only the
   // Observable-specific macro ranges (`viewof foo` → $N, `mutable foo` →
@@ -2931,7 +2746,7 @@ const _1v1i7wl = function _observableToJs(acorn_walk,parser){return(
   return out;
 }
 )};
-const _1ayjluu = function _161(md){return(
+const _1hd7px0 = function _152(md){return(
 md`### Bundled deps`
 )};
 const _xhj6b8 = function _decompress_url(DecompressionStream,TextDecoderStream,TransformStream,TextEncoderStream,Response){return(
@@ -2968,19 +2783,19 @@ async (attachment, overrides) => {
   return URL.createObjectURL(blob);
 }
 )};
-const _s9w7ha = async function _parser(decompress_url, FileAttachment, acorn_url, acorn_walk_url) {
-    return import(await decompress_url(FileAttachment('parser-6.1.0.js.gz'), {
-        '/npm/acorn@8.11.3/+esm': acorn_url,
-        '/npm/acorn-walk@8.3.2/+esm': acorn_walk_url
-    }));
-};
-const _1rc67k0 = function _stageB_importFake()
+const _s9w7ha = async function _parser(decompress_url,FileAttachment,acorn_url,acorn_walk_url){return(
+import(await decompress_url(FileAttachment("parser-6.1.0.js.gz"), {
+    "/npm/acorn@8.11.3/+esm": acorn_url,
+    "/npm/acorn-walk@8.3.2/+esm": acorn_walk_url
+  }))
+)};
+const _j9n5de = function _stageB_importFake()
 {
-  return // Builds a Stage B (pre-observation, API-loaded) import group as POJOs.
+  // Builds a Stage B (pre-observation, API-loaded) import group as POJOs.
   // Mirrors what `runtime.define("name", ["module @X", "@variable"], (_, v) => v.import("name", _))`
   // produces structurally. Used by the test_decompileImport_stageB_* tests to
   // avoid spinning up a real Observable runtime per case.
-  function stageB_importFake(module_name, specifiers) {
+  return function stageB_importFake(module_name, specifiers) {
     const importerModule = { _scope: new Map() };
     const stitch = {
       _name: `module ${ module_name }`,
@@ -3134,10 +2949,10 @@ const _rk7ku3 = async function _test_decompileImport_compile_roundtrip_single(co
   expect(formatImportDeclaration(info)).toEqual(`import {visualize, Group} from "@tomlarkworthy/visualizer"`);
   return 'ok';
 };
-const _xynplo = async function _test_decompileImport_stageB_order_independent(stageB_importFake,decompileImport,expect,formatImportDeclaration)
+const _1numivw = async function _test_decompileImport_stageB_order_independent(stageB_importFake,decompileImport,expect,formatImportDeclaration)
 {
   // The detection uses .find — it shouldn't matter whether the stitch is at
-  // index 0 or the aliases come first. Verify by reversing the array.
+  // index 0 or the aliases come first. Verify by moving it to the end.
   const vars = stageB_importFake('@user/y', [
     {
       imported: 'a',
@@ -3148,8 +2963,11 @@ const _xynplo = async function _test_decompileImport_stageB_order_independent(st
       local: 'b'
     }
   ]);
-  const reversed = [...vars].reverse();
-  const info = await decompileImport(reversed);
+  const [stitch, ...aliases] = vars;
+  const info = await decompileImport([
+    ...aliases,
+    stitch
+  ]);
   expect(info.meta.detection.stage).toEqual('B');
   expect(formatImportDeclaration(info)).toEqual(`import {a, b} from "@user/y"`);
   return 'ok';
@@ -3166,13 +2984,143 @@ const _16fpgac = async function _test_decompileImport_stageB_notebook_id(stageB_
   expect(formatImportDeclaration(info)).toEqual(`import {hash} from "d/57d79353bac56631@44"`);
   return 'ok';
 };
+const _r2e0wl = function _test_extractModuleInfo_new_id_resolutions(expect,extractModuleInfo)
+{
+  // new.observablehq.com d/<id>@<ver> import with resolutions=.
+  expect(
+    extractModuleInfo(
+      'async () => runtime.module((await import("/d/e1c39d41e8e944b0@939.js?v=4&resolutions=a6a56ee61aba9799@437")).default)'
+    )
+  ).toEqual({ id: "e1c39d41e8e944b0", version: "939" });
+  return "ok";
+};
+const _1pg1y6s = function _test_extractModuleInfo_new_slug_resolutions(expect,extractModuleInfo)
+{
+  // new.observablehq.com slug import carries a resolutions= param.
+  expect(
+    extractModuleInfo(
+      'async () => runtime.module((await import("/@mootari/access-runtime.js?v=4&resolutions=98f34e974bb2e4bc@1392")).default)'
+    )
+  ).toEqual({ namespace: "mootari", notebook: "access-runtime", version: "1392" });
+  return "ok";
+};
+const _1vh26m0 = function _test_findModuleName_classic_bundle(expect,findModuleName)
+{
+  // classic observablehq.com bundles imports; the holder def is a bare slug import.
+  const m = {}; // module sentinel
+  const scope = new Map([
+    ["module 1", { _name: "module 1", _value: m,
+      _definition: 'async () => runtime.module((await import("@tomlarkworthy/flow-queue")).default)' }]
+  ]);
+  expect(findModuleName(scope, m)).toEqual("@tomlarkworthy/flow-queue");
+  return "ok";
+};
+const _1ltqcwj = function _test_findModuleName_kit_slug(expect,findModuleName)
+{
+  // Notebook Kit compiles observable imports to import("https://api.observablehq.com/@u/nb.js?v=4").
+  const m = {}; // module sentinel
+  const scope = new Map([
+    ["module 1", { _name: "module 1", _value: m,
+      _definition: 'async (__ojs_runtime) => __ojs_runtime.module((await import("https://api.observablehq.com/@d3/color-legend.js?v=4")).default)' }]
+  ]);
+  expect(findModuleName(scope, m)).toEqual("@d3/color-legend");
+  return "ok";
+};
+const _wq4poo = function _test_findModuleName_new_id(expect,findModuleName)
+{
+  const m = {}; // module sentinel
+  const scope = new Map([
+    ["module 1", { _name: "module 1", _value: m,
+      _definition: 'async () => runtime.module((await import("/d/e1c39d41e8e944b0@939.js?v=4&resolutions=a6a56ee61aba9799@437")).default)' }]
+  ]);
+  expect(findModuleName(scope, m)).toEqual("d/e1c39d41e8e944b0@939");
+  return "ok";
+};
+const _1j0hksu = function _test_findModuleName_new_slug(expect,findModuleName)
+{
+  const m = {}; // module sentinel
+  const scope = new Map([
+    ["module 1", { _name: "module 1", _value: m,
+      _definition: 'async () => runtime.module((await import("/@mootari/access-runtime.js?v=4&resolutions=98f34e974bb2e4bc@1392")).default)' }]
+  ]);
+  expect(findModuleName(scope, m)).toEqual("@mootari/access-runtime");
+  return "ok";
+};
+const _3en7eq = async function _test_decompile_leading_comment(decompile,expect,compile)
+{
+  // Regression: a comment in the compiler's auto-wrap slot (`return( // note\n42 )`)
+  // is preserved in ASI-safe block form — never the hazardous `return` + comment
+  // + newline WITHOUT the paren that evaluated to undefined on ObservableHQ.
+  const src = await decompile([
+    { _name: "c", _definition: `function _c(){return( // note\n42\n)}`, _inputs: [] }
+  ]);
+  expect(src).toEqual(`c = {return( // note\n42\n)}`);
+  // It keeps the ASI-protecting paren and round-trips through compile to 42.
+  const cell = compile(src);
+  const first = Array.isArray(cell) ? cell[0] : cell;
+  const def = first._definition || (first.cells && first.cells[0]._definition);
+  expect(eval(`(${def})`)()).toEqual(42);
+  return "ok";
+};
+const _z17nwa = async function _test_decompile_trailing_comment(decompile,expect)
+{
+  // Regression: a comment that survives compile inside the block (trailing on the
+  // return line, or before the closing brace) must survive decompile too — don't
+  // unwrap a single-return block when a comment sits outside the returned value.
+  const trailing = await decompile([
+    { _name: "x", _definition: `function _x(){\n  return 1; // done\n}`, _inputs: [] }
+  ]);
+  expect(trailing).toEqual(`x = {\n  return 1; // done\n}`);
+  const tail = await decompile([
+    { _name: "y", _definition: `function _y(){\n  return 1;\n  // tail\n}`, _inputs: [] }
+  ]);
+  expect(tail).toEqual(`y = {\n  return 1;\n  // tail\n}`);
+  return "ok";
+};
+const _q5y9bo = async function _test_decompile_param_in_string(decompile,expect)
+{
+  // Regression: renaming an underscore-encoded viewof/mutable param must rewrite
+  // only identifier references, never same-spelled text inside a string literal
+  // (range-based splice, not the old source.replaceAll).
+  const decompiled = await decompile([
+    {
+      _name: "u",
+      _definition: `function _u(viewof_x){return(\n"viewof_x literal" + viewof_x\n)}`,
+      _inputs: ["viewof x"]
+    }
+  ]);
+  expect(decompiled).toEqual(`u = "viewof_x literal" + viewof x`);
+  return "ok";
+};
+const _fm2sgc = async function _test_decompile_class_property_field(decompile,expect)
+{
+  // Regression: a class field declaration must decompile cleanly. Source-slicing
+  // sidesteps the escodegen shim gap that threw "this[d] is not a function".
+  const decompiled = await decompile([
+    {
+      _name: "Cls",
+      _definition: `function _Cls(){return(\nclass Cls {\n  d;\n}\n)}`,
+      _inputs: []
+    }
+  ]);
+  expect(decompiled).toEqual(`Cls = class Cls {\n  d;\n}`);
+  return "ok";
+};
+const _1xp8nli = async function _test_compile_preserves_formatting(compile,expect)
+{
+  // Source-preserving compile keeps quote style and template spacing verbatim;
+  // escodegen used to re-quote ("h1" -> 'h1') and respace (${s} -> ${ s }).
+  const compiled = await compile('x = { const s = "h1"; return `${s}`; }');
+  expect(compiled[0]._definition).toEqual('function _x() { const s = "h1"; return `${s}`; }');
+  return "ok";
+};
 
 export default function define(runtime, observer) {
   const main = runtime.module();
   const $def = (pid, name, deps, fn) => {
     main.variable(observer(name)).define(name, deps, fn).pid = pid;
   };
-  const fileAttachments = new Map(["acorn-walk-8.3.2.js.gz","parser-6.1.0.js.gz"].map((name) => {
+  const fileAttachments = new Map(["parser-6.1.0.js.gz"].map((name) => {
     const module_name = "@tomlarkworthy/observablejs-toolchain";
     const {status, mime, bytes} = window.lopecode.contentSync(module_name + "/" + encodeURIComponent(name));
     const blob_url = URL.createObjectURL(new Blob([bytes], { type: mime}));
@@ -3182,7 +3130,6 @@ export default function define(runtime, observer) {
 
   main.define("module @tomlarkworthy/tests", async () => runtime.module((await import("/@tomlarkworthy/tests.js?v=4")).default));  
   main.define("module @tomlarkworthy/cell-map", async () => runtime.module((await import("/@tomlarkworthy/cell-map.js?v=4")).default));  
-  main.define("module @tomlarkworthy/escodegen", async () => runtime.module((await import("/@tomlarkworthy/escodegen.js?v=4")).default));  
   main.define("module @tomlarkworthy/acorn-8-11-3", async () => runtime.module((await import("/@tomlarkworthy/acorn-8-11-3.js?v=4")).default));  
   main.define("module @tomlarkworthy/jest-expect-standalone", async () => runtime.module((await import("/@tomlarkworthy/jest-expect-standalone.js?v=4")).default));  
   main.define("module @tomlarkworthy/observable-runtime", async () => runtime.module((await import("/@tomlarkworthy/observable-runtime.js?v=4")).default));  
@@ -3208,7 +3155,7 @@ export default function define(runtime, observer) {
   $def("_x55zzr", "test_decompiled_cells_recompilable", ["all_compiled"], _x55zzr);  
   $def("_100n7xr", null, ["md"], _100n7xr);  
   $def("_1nm57o2", "roundtripped", ["all_compiled","decompile"], _1nm57o2);  
-  $def("_18xo2td", "test_all_cells_roundtrippable", ["roundtripped"], _18xo2td);  
+  $def("_1shi9or", "test_all_cells_roundtrippable", ["roundtripped"], _1shi9or);  
   $def("_14nox99", null, ["md"], _14nox99);  
   $def("_1d3zr3i", null, ["md"], _1d3zr3i);  
   $def("_12sqt9", "dependancy_document", [], _12sqt9);  
@@ -3228,137 +3175,122 @@ export default function define(runtime, observer) {
   $def("_25tjxa", "test_decompile_syntax_error_roundtrip", ["compile","decompile","expect"], _25tjxa);  
   $def("_1jyrnzq", "test_decompile_$variable", ["decompile","expect"], _1jyrnzq);  
   $def("_1v1d8m3", "test_decompile_import_variable", ["decompile","importFake","expect"], _1v1d8m3);  
-  $def("_fiyb80", "test_decompile_dollar_in_string_literal", ["decompile","expect"], _fiyb80);  
+  $def("_1ybjsqg", "test_decompile_dollar_in_string_literal", ["decompile","expect"], _1ybjsqg);  
   $def("_wgfrtq", "test_decompile_import_variable_alias", ["decompile","importFake","expect"], _wgfrtq);  
   $def("_1a8gnrc", "test_decompile_import_many", ["decompile","importFake","expect"], _1a8gnrc);  
   $def("_7stpu3", "test_decompile_markdown_cell", ["decompile","expect"], _7stpu3);  
   $def("_v4p1js", "test_decompile_constant", ["decompile","expect"], _v4p1js);  
-  $def("_pcs4h", "test_decompile_string_literal", ["decompile","expect"], _pcs4h);  
+  $def("_1puzspw", "test_decompile_string_literal", ["decompile","expect"], _1puzspw);  
   $def("_a2zh99", "test_decompile_html_cell", ["decompile","expect"], _a2zh99);  
-  $def("_pyp280", "test_decompile_class", ["decompile","expect"], _pyp280);  
+  $def("_1pt67ao", "test_decompile_class", ["decompile","expect"], _1pt67ao);  
   $def("_kf8c3f", "test_decompile_class_with_property", ["decompile"], _kf8c3f);  
-  $def("_4vunhm", "test_decompile_object_literal", ["decompile","expect"], _4vunhm);
-  $def("_tstlc1", "test_decompile_leading_comment", ["compile","decompile","expect"], _tstlc1);
-  $def("_tsttc1", "test_decompile_trailing_comment", ["decompile","expect"], _tsttc1);
-  $def("_tstpis", "test_decompile_param_in_string", ["decompile","expect"], _tstpis);
-  $def("_tstcpf", "test_decompile_class_property_field", ["decompile","expect"], _tstcpf);
+  $def("_4vunhm", "test_decompile_object_literal", ["decompile","expect"], _4vunhm);  
   $def("_s14e29", "test_decompile_reference", ["decompile","expect"], _s14e29);  
-  $def("_4rsshj", "test_decompile_block", ["decompile","expect"], _4rsshj);  
-  $def("_o7o1wl", "test_decompile_comments", ["decompile","expect"], _o7o1wl);  
+  $def("_14nvmno", "test_decompile_block", ["decompile","expect"], _14nvmno);  
+  $def("_5kd9if", "test_decompile_comments", ["decompile","expect"], _5kd9if);  
   $def("_1yn35e3", "test_decompile_generator", ["decompile","expect"], _1yn35e3);  
-  $def("_135eswd", "test_decompile_function", ["decompile","expect"], _135eswd);  
-  $def("_1pitq2", "test_decompile_async_function", ["decompile","expect"], _1pitq2);  
-  $def("_1kxe1b2", "test_decompile_named_function", ["decompile","expect"], _1kxe1b2);  
+  $def("_10wf7cf", "test_decompile_function", ["decompile","expect"], _10wf7cf);  
+  $def("_1191zxm", "test_decompile_async_function", ["decompile","expect"], _1191zxm);  
+  $def("_vpu09i", "test_decompile_named_function", ["decompile","expect"], _vpu09i);  
   $def("_1pghf4f", "test_decompile_this_reference", ["decompile","expect"], _1pghf4f);  
-  $def("_4aeghn", "test_decompile_lambda", ["decompile","expect"], _4aeghn);  
+  $def("_rajn7p", "test_decompile_lambda", ["decompile","expect"], _rajn7p);  
   $def("_12ec5zd", "test_decompile_error", ["decompile","expect"], _12ec5zd);  
-  $def("_3bj09h", "test_decompile_error_object", ["decompile","expect"], _3bj09h);  
+  $def("_1c93ef9", "test_decompile_error_object", ["decompile","expect"], _1c93ef9);  
   $def("_6iufw4", null, ["md"], _6iufw4);  
   $def("_15idqib", "test_decompile_anon_error_dep", ["decompile","expect"], _15idqib);  
   $def("_mhm98c", "test_decompile_viewof", ["decompile","expect"], _mhm98c);  
   $def("_15kgqrr", "test_decompile_mutable", ["decompile","expect"], _15kgqrr);  
   $def("_1onyv5c", "test_decompile_builtin", ["decompile","expect"], _1onyv5c);  
-  $def("_1uv76xx", "test_decompile_fileattachment", ["decompile","expect"], _1uv76xx);  
+  $def("_4z1dnp", "test_decompile_fileattachment", ["decompile","expect"], _4z1dnp);  
   $def("_g4z6de", "test_decompile_mutable_dependancy", ["decompile","expect"], _g4z6de);  
   $def("_qo8sdl", "test_decompile_mutable_dependancy_2", ["decompile","expect"], _qo8sdl);  
   $def("_15kwaz1", "test_decompile_viewof_dep", ["decompile","expect"], _15kwaz1);  
   $def("_1qjzk2s", "test_decompile_viewof_data_dep", ["decompile","expect"], _1qjzk2s);  
-  $def("_ehz2xk", "test_decompile_viewof_param", ["decompile","expect"], _ehz2xk);  
+  $def("_b0y8zg", "test_decompile_viewof_param", ["decompile","expect"], _b0y8zg);  
   $def("_oilkc0", "test_decompile_anon_dep", ["decompile","expect"], _oilkc0);  
-  $def("_1jggajo", "test_decompile_import_mutable", ["decompile","expect"], _1jggajo);  
-  $def("_di0abi", "test_decompile_import_viewof", ["decompile","expect"], _di0abi);  
-  $def("_14o5oio", "test_decompile_viewof_data", ["decompile","expect"], _14o5oio);  
-  $def("_1lv4syw", "test_decompile_import_alias", ["decompile","expect"], _1lv4syw);  
-  $def("_l8b8hu", "test_decompile_import_mutable_alias", ["decompile","expect"], _l8b8hu);  
-  $def("_1g5n3sa", "test_decompile_import_mutable_data_alias", ["decompile","expect"], _1g5n3sa);  
-  $def("_1lnngk6", "test_decompile_import_viewof_alias", ["decompile","expect"], _1lnngk6);  
-  $def("_1na1e5i", "test_decompile_import_viewof_data_alias", ["decompile","expect"], _1na1e5i);  
+  $def("_1eqf4jq", "test_decompile_import_mutable", ["decompile","expect"], _1eqf4jq);  
+  $def("_3damo4", "test_decompile_import_viewof", ["decompile","expect"], _3damo4);  
+  $def("_1l9xqsw", "test_decompile_viewof_data", ["decompile","expect"], _1l9xqsw);  
+  $def("_1cggvdk", "test_decompile_import_alias", ["decompile","expect"], _1cggvdk);  
+  $def("_xcwq4", "test_decompile_import_mutable_alias", ["decompile","expect"], _xcwq4);  
+  $def("_1868h0w", "test_decompile_import_mutable_data_alias", ["decompile","expect"], _1868h0w);  
+  $def("_1afcxhk", "test_decompile_import_viewof_alias", ["decompile","expect"], _1afcxhk);  
+  $def("_1sl510", "test_decompile_import_viewof_data_alias", ["decompile","expect"], _1sl510);  
   $def("_17dwb6r", null, ["md"], _17dwb6r);  
-  main.define("escodegen", ["module @tomlarkworthy/escodegen", "@variable"], (_, v) => v.import("escodegen", _));  
-  $def("_1vs6mei", null, ["md"], _1vs6mei);  
-  $def("_1g89k6a", "escodegenOptions", ["escodegen"], _1g89k6a);  
-  $def("_llvq9s", "decompile", ["decompileImport","formatImportDeclaration","acorn","escodegen","escodegenOptions"], _llvq9s);  
-  $def("_1pvis67", null, ["md"], _1pvis67);  
+  $def("_1ngipml", null, ["md"], _1ngipml);  
+  $def("_2d5g1", "decompile", ["decompileImport","formatImportDeclaration","acorn"], _2d5g1);  
+  $def("_1x0pvrl", null, ["md"], _1x0pvrl);  
   $def("_183j58u", "extractModuleInfo", [], _183j58u);  
   $def("_w445v0", "test_extractModuleInfo_notebook_resolution", ["expect","extractModuleInfo"], _w445v0);  
   $def("_uzqj4w", "test_extractModuleInfo_id_version_resolution", ["expect","extractModuleInfo"], _uzqj4w);  
   $def("_1sruec2", "test_extractModuleInfo_id_version", ["expect","extractModuleInfo"], _1sruec2);  
   $def("_ipn8zp", "test_extractModuleInfo_test_4", ["expect","extractModuleInfo"], _ipn8zp);  
   $def("_iigmyv", "test_extractModuleInfo_alias_hack", ["expect","extractModuleInfo"], _iigmyv);  
-  $def("_1tggbee", null, ["md"], _1tggbee);  
+  $def("_7t42k8", null, ["md"], _7t42k8);  
   $def("_kiaw33", "import_ast_example", ["parser"], _kiaw33);  
   $def("_1n7gw17", "findModuleName", ["extractModuleInfo"], _1n7gw17);  
   $def("_i47chb", "findImportedName", [], _i47chb);  
-  $def("_1effqg", null, ["md"], _1effqg);  
-  $def("_b7vai6", "decompileImport", ["findModuleName","findImportedName"], _b7vai6);  
+  $def("_ed3cy2", null, ["md"], _ed3cy2);  
+  $def("_1a4j4gm", "decompileImport", ["findModuleName","findImportedName"], _1a4j4gm);  
   $def("_1sylz7j", "formatImportDeclaration", [], _1sylz7j);  
   $def("_13dctdn", "test_decompileImport_basic", ["importFake","decompileImport","expect"], _13dctdn);  
   $def("_ujr0xn", "test_formatImportDeclaration_roundtrip", ["importFake","decompileImport","expect","formatImportDeclaration","decompile"], _ujr0xn);  
   $def("_1u6sfri", "test_decompileImport_alias", ["importFake","decompileImport","expect","formatImportDeclaration"], _1u6sfri);  
-  $def("_1lqhutp", null, ["md"], _1lqhutp);  
-  $def("_ikzxev", "normalizeJavascriptSource", ["acorn","escodegen"], _ikzxev);  
-  $def("_az8lo6", "normalizeVariables", ["variableToObject","normalizeJavascriptSource"], _az8lo6);  
+  $def("_1lti0tv", null, ["md"], _1lti0tv);  
   $def("_3knb9v", "variableToObject", [], _3knb9v);  
-  $def("_263fcv", null, ["md"], _263fcv);  
+  $def("_autn1v", null, ["md"], _autn1v);  
   $def("_7zpsl9", "viewof normalizeObservableSourceSelector", ["Inputs","notebook_semantics_source"], _7zpsl9);  
   $def("_1ex8kus", "normalizeObservableSourceSelector", ["Generators","viewof normalizeObservableSourceSelector"], _1ex8kus);  
-  $def("_17petbz", null, ["normalizeObservableSource","normalizeObservableSourceSelector"], _17petbz);  
   $def("_b2d0zc", "parsed", ["parser","normalizeObservableSourceSelector"], _b2d0zc);  
-  $def("_qtgjo9", "generate", ["escodegen"], _qtgjo9);  
-  $def("_104j23i", "normalizeObservableSource", ["parser","generate"], _104j23i);  
-  $def("_vle3wv", null, ["md"], _vle3wv);  
+  $def("_14qm8or", null, ["md"], _14qm8or);  
   $def("_10ofthe", "test_async_interpolation", ["compile"], _10ofthe);  
   $def("_1gb7c3c", "test_compile_syntax_error_viewof", ["compile","expect"], _1gb7c3c);  
   $def("_69vyub", "test_compile_syntax_error_anonymous", ["compile","expect"], _69vyub);  
   $def("_1c9p3om", "test_compile_syntax_error_named", ["compile","expect"], _1c9p3om);  
   $def("_x7zc8w", "test_compile_integer", ["compile","expect"], _x7zc8w);  
-  $def("_1u7hlem", "test_compile_string", ["compile","expect"], _1u7hlem);  
-  $def("_151bijp", "test_compile_obj_literal", ["compile","expect"], _151bijp);
-  $def("_tstcff", "test_compile_preserves_formatting", ["compile","expect"], _tstcff);  
-  $def("_ti9okn", "test_compile_assignment", ["compile","expect"], _ti9okn);  
+  $def("_1qp2ggw", "test_compile_string", ["compile","expect"], _1qp2ggw);  
+  $def("_151bijp", "test_compile_obj_literal", ["compile","expect"], _151bijp);  
+  $def("_17z4vyt", "test_compile_assignment", ["compile","expect"], _17z4vyt);  
   $def("_1eb8vq", "test_compile_dependancy", ["compile","expect"], _1eb8vq);  
-  $def("_acs4l0", "test_compile_block_dependancy", ["compile","expect"], _acs4l0);  
-  $def("_125ljg9", "test_compile_comments", ["compile","expect"], _125ljg9);  
-  $def("_li37je", "test_compile_generator", ["compile","expect"], _li37je);  
-  $def("_em4em6", "test_compile_function", ["compile","expect"], _em4em6);  
-  $def("_w3atfb", "test_compile_async_function", ["compile","expect"], _w3atfb);  
-  $def("_14gl6yr", "test_compile_named_function", ["compile","expect"], _14gl6yr);  
+  $def("_5b8x33", "test_compile_block_dependancy", ["compile","expect"], _5b8x33);  
+  $def("_9s1umz", "test_compile_comments", ["compile","expect"], _9s1umz);  
+  $def("_1rbs7b6", "test_compile_generator", ["compile","expect"], _1rbs7b6);  
+  $def("_1gaxmhs", "test_compile_function", ["compile","expect"], _1gaxmhs);  
+  $def("_2ozyn1", "test_compile_async_function", ["compile","expect"], _2ozyn1);  
+  $def("_1jn3lk9", "test_compile_named_function", ["compile","expect"], _1jn3lk9);  
   $def("_z3bqb8", "test_compile_this_reference", ["compile","expect"], _z3bqb8);  
-  $def("_1sou7t0", "test_compile_lambda", ["compile","expect"], _1sou7t0);  
-  $def("_1o1u737", "test_compile_error", ["compile","expect"], _1o1u737);  
+  $def("_1lyze5m", "test_compile_lambda", ["compile","expect"], _1lyze5m);  
+  $def("_12k1xub", "test_compile_error", ["compile","expect"], _12k1xub);  
   $def("_y271kb", "test_compile_viewof", ["compile","expect"], _y271kb);  
   $def("_1q4asyp", "test_compile_viewof_and_value_coexist", ["compile","expect"], _1q4asyp);  
   $def("_189jvkd", "test_compile_mutable", ["compile","expect"], _189jvkd);  
   $def("_78egw8", "test_compile_builtin", ["compile","expect"], _78egw8);  
-  $def("_lflzev", "test_compile_fileattachment", ["compile","expect"], _lflzev);  
-  $def("_1e555b1", "test_compile_mutable_dep", ["compile","expect"], _1e555b1);  
-  $def("_1a2af6", "test_compile_mutable_dep2", ["compile","expect"], _1a2af6);  
+  $def("_1o65727", "test_compile_fileattachment", ["compile","expect"], _1o65727);  
+  $def("_14c9yxp", "test_compile_mutable_dep", ["compile","expect"], _14c9yxp);  
+  $def("_133w84q", "test_compile_mutable_dep2", ["compile","expect"], _133w84q);  
   $def("_ql80wk", "test_compile_inline_viewof", ["compile","expect"], _ql80wk);  
   $def("_1k420gu", "test_compile_view_dep", ["compile","expect"], _1k420gu);  
   $def("_1y1h47u", "test_compile_dep", ["compile","expect"], _1y1h47u);  
-  $def("_kwdsyz", "test_compile_class", ["compile","expect"], _kwdsyz);  
+  $def("_1r711sh", "test_compile_class", ["compile","expect"], _1r711sh);  
   $def("_33oop5", "test_compile_event", ["compile","expect"], _33oop5);  
   $def("_9phvzk", "test_compile_tagged_literal", ["compile","expect"], _9phvzk);  
   $def("_1q0pie3", "compile_unit_test_template", ["Inputs","test_case","compiled"], _1q0pie3);  
-  $def("_1lmax86", "test_compile_import_plain_single", ["compile","expect"], _1lmax86);  
-  $def("_17sgzdm", "test_compile_import_view_data_alias_single", ["compile","expect"], _17sgzdm);  
-  $def("_1tqj4tp", "test_compile_import_mutable_data_alias_single", ["compile","expect"], _1tqj4tp);  
-  $def("_hv0te2", "test_compile_import_mutable_single", ["compile","expect"], _hv0te2);  
-  $def("_1mltqmr", "test_compile_import_viewof_single", ["compile","expect"], _1mltqmr);  
-  $def("_1d18obr", "test_compile_import_alias_single", ["compile","expect"], _1d18obr);  
-  $def("_1b5ghef", "test_compile_import_notebook", ["compile","expect"], _1b5ghef);  
+  $def("_1vg114c", "test_compile_import_plain_single", ["compile","expect"], _1vg114c);  
+  $def("_18h6y38", "test_compile_import_view_data_alias_single", ["compile","expect"], _18h6y38);  
+  $def("_1svcdun", "test_compile_import_mutable_data_alias_single", ["compile","expect"], _1svcdun);  
+  $def("_tb4ops", "test_compile_import_mutable_single", ["compile","expect"], _tb4ops);  
+  $def("_vuzib9", "test_compile_import_viewof_single", ["compile","expect"], _vuzib9);  
+  $def("_6ewshd", "test_compile_import_alias_single", ["compile","expect"], _6ewshd);  
+  $def("_36migr", "test_compile_import_notebook", ["compile","expect"], _36migr);  
   $def("_1nps9cr", "viewof test_case", ["Inputs","notebook_semantics_source"], _1nps9cr);  
   $def("_1e5ax6f", "test_case", ["Generators","viewof test_case"], _1e5ax6f);  
-  $def("_18e5b93", null, ["test_case"], _18e5b93);  
+  $def("_7eic89", null, ["test_case"], _7eic89);  
   $def("_16q6oyc", "compiled", ["compile","test_case"], _16q6oyc);  
-  $def("_1191170", null, ["parser","test_case"], _1191170);  
-  $def("_1gh543z", "viewof compiled_selector", ["Inputs","compiled"], _1gh543z);  
-  $def("_1dmmuaf", "compiled_selector", ["Generators","viewof compiled_selector"], _1dmmuaf);  
-  $def("_1klx74n", null, ["compiled_selector","normalizeJavascriptSource"], _1klx74n);  
-  $def("_eom91x", null, ["compile","test_case"], _eom91x);  
-  $def("_ttos3c", "compile", ["parser","observableToJs"], _ttos3c);  
-  $def("_1v1i7wl", "observableToJs", ["acorn_walk","parser"], _1v1i7wl);  
-  $def("_1ayjluu", null, ["md"], _1ayjluu);  
+  $def("_61dayu", null, ["parser","test_case"], _61dayu);  
+  $def("_cevs6r", null, ["compile","test_case"], _cevs6r);  
+  $def("_mliwy8", "compile", ["parser","observableToJs"], _mliwy8);  
+  $def("_16p8atj", "observableToJs", ["acorn_walk","parser"], _16p8atj);  
+  $def("_1hd7px0", null, ["md"], _1hd7px0);  
   $def("_xhj6b8", "decompress_url", ["DecompressionStream","TextDecoderStream","TransformStream","TextEncoderStream","Response"], _xhj6b8);  
   $def("_s9w7ha", "parser", ["decompress_url","FileAttachment","acorn_url","acorn_walk_url"], _s9w7ha);  
   main.define("acorn", ["module @tomlarkworthy/acorn-8-11-3", "@variable"], (_, v) => v.import("acorn", _));  
@@ -3370,7 +3302,7 @@ export default function define(runtime, observer) {
   main.define("Inspector", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Inspector", _));  
   main.define("Library", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("Library", _));  
   main.define("RuntimeError", ["module @tomlarkworthy/observable-runtime", "@variable"], (_, v) => v.import("RuntimeError", _));  
-  $def("_1rc67k0", "stageB_importFake", [], _1rc67k0);  
+  $def("_j9n5de", "stageB_importFake", [], _j9n5de);  
   $def("_1d53asg", "test_decompileImport_stageB_single", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1d53asg);  
   $def("_hv5gag", "test_decompileImport_stageB_aliased", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _hv5gag);  
   $def("_avc18y", "test_decompileImport_stageB_multiple", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _avc18y);  
@@ -3379,7 +3311,18 @@ export default function define(runtime, observer) {
   $def("_qwlsf2", "test_decompileImport_stageB_mutable", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _qwlsf2);  
   $def("_sy7jfx", "test_decompileImport_returns_null_for_non_import", ["decompileImport","expect"], _sy7jfx);  
   $def("_rk7ku3", "test_decompileImport_compile_roundtrip_single", ["compile","expect","stageB_importFake","decompileImport","formatImportDeclaration"], _rk7ku3);  
-  $def("_xynplo", "test_decompileImport_stageB_order_independent", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _xynplo);  
-  $def("_16fpgac", "test_decompileImport_stageB_notebook_id", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16fpgac);
+  $def("_1numivw", "test_decompileImport_stageB_order_independent", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _1numivw);  
+  $def("_16fpgac", "test_decompileImport_stageB_notebook_id", ["stageB_importFake","decompileImport","expect","formatImportDeclaration"], _16fpgac);  
+  $def("_r2e0wl", "test_extractModuleInfo_new_id_resolutions", ["expect","extractModuleInfo"], _r2e0wl);  
+  $def("_1pg1y6s", "test_extractModuleInfo_new_slug_resolutions", ["expect","extractModuleInfo"], _1pg1y6s);  
+  $def("_1vh26m0", "test_findModuleName_classic_bundle", ["expect","findModuleName"], _1vh26m0);  
+  $def("_1ltqcwj", "test_findModuleName_kit_slug", ["expect","findModuleName"], _1ltqcwj);  
+  $def("_wq4poo", "test_findModuleName_new_id", ["expect","findModuleName"], _wq4poo);  
+  $def("_1j0hksu", "test_findModuleName_new_slug", ["expect","findModuleName"], _1j0hksu);  
+  $def("_3en7eq", "test_decompile_leading_comment", ["decompile","expect","compile"], _3en7eq);  
+  $def("_z17nwa", "test_decompile_trailing_comment", ["decompile","expect"], _z17nwa);  
+  $def("_q5y9bo", "test_decompile_param_in_string", ["decompile","expect"], _q5y9bo);  
+  $def("_fm2sgc", "test_decompile_class_property_field", ["decompile","expect"], _fm2sgc);  
+  $def("_1xp8nli", "test_compile_preserves_formatting", ["compile","expect"], _1xp8nli);
   return main;
 }


### PR DESCRIPTION
Lands the escodegen removal on main. Notebook artifacts merged as [lopecode#203](https://github.com/tomlarkworthy/lopecode/pull/203).

**Module store**
- `modules/@tomlarkworthy/exporter-3.js` — refreshed from Observable v17204. `restoreCanonicalImports` now splices the callee character ranges from the acorn AST instead of regenerating each cell through `escodegen.generate()`, the same source-preserving approach as the toolchain's `observableToJs`. escodegen is unused and its import is gone, taking 44KB out of every exporter-3 bundle.
- `modules/@tomlarkworthy/observablejs-toolchain.js` — refreshed from the re-jumpgated notebook (Observable v7846). Its remaining `escodegen` mentions are a test fixture building a fake import group, not a real import.

**Submodule** `5a07e88 -> 51b1ac8`, which carries the re-jumpgated `jumpgates.html` (real dual-main export, replacing a `sync-module` patch) and toolchain notebook, plus the exporter-3 prerender default the pointer was lagging behind.

Two deliberate behaviour differences vs the escodegen path:

- **Import attributes survive.** escodegen rebuilt each call as an `ImportExpression` carrying only `source`, so `importShim(url, {with: {type: 'css'}})` exported as `import(url)` with the attributes silently dropped.
- **The es-module-shims parent URL is still dropped, now explicitly.** Observable compiles a cell's own `import(x)` into `importShim(x, "<notebook url>")` — argument 2 is a parent URL, not options. Keying on string-vs-object handles both.

Verified: exporter-3 7/7 and toolchain 114/114 on the jumpgated bundles, exporter-3 re-exported through itself to a byte-identical fixed point, 0 non-canonical two-argument imports, all three jumpgate mains and upstreams intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)