### PR TITLE
spec-sync maintains bootconf; lope-jumpgate reads mains from it

### DIFF
--- a/knowledge/maintaining-and-updating-lopecode-and-lopebook-content-repositories.md
+++ b/knowledge/maintaining-and-updating-lopecode-and-lopebook-content-repositories.md
@@ -45,15 +45,21 @@ node tools/lope-jumpgate.js \
 
 | Arg | Default | Description |
 |-----|---------|-------------|
-| `--source <name>` | (required) | Observable notebook shorthand |
-| `--frame <name>` | `@tomlarkworthy/lopepage` | Frame notebook shorthand |
+| `--source <name>` | the non-frame entries of the output spec's `bootconf.mains` | Observable notebook shorthand. Required only when there is no spec to derive it from |
+| `--frame <name>` | the `lopepage*` entry of the output spec's `bootconf.mains`, else `@tomlarkworthy/lopepage` | Frame notebook shorthand |
 | `--jumpgate <path>` | `lopecode/notebooks/jumpgates.html` | Path to jumpgate HTML |
 | `--output <path>` | (required) | Where to write the exported HTML |
 | `--hash <hash>` | existing spec or side-panel | Hash for bootconf (e.g. `#view=@author/notebook`) |
 | `--theme <name>` | existing spec or none | Theme name (e.g. `near-midnight`) |
+| `--no-carry-mains` | false | Ignore the spec's `bootconf.mains` — the pre-2026-08-13 behaviour. Use when deliberately narrowing what a notebook boots, or to export one source at a time under Observable's rate limit |
+| `--dry-run` | false | Print the resolved frame/sources/mains as JSON and exit, without launching a browser |
 | `--timeout <ms>` | `120000` | Max wait for export |
 | `--headed` | false | Show browser for debugging |
 | `--verbose` | false | Show browser console logs |
+
+`--source` stays the primary — it drives the title and the default hash — and carried mains are
+appended after it. An explicit `--frame` swaps the recorded frame out rather than adding to it.
+The spec's `bootconf` is kept in step with the HTML by the `lope-spec-sync` pre-commit hook.
 
 Jumpgate writes per-module upstream URLs to the `.json` spec file as `"upstreams"`, a `host → module → url` map (currently only `observablehq.com` is populated). For the single-source case the map has one entry; for multi-source bundles it records every primary. `lope-push-ws.js` reads `upstreams["observablehq.com"][--module]` as a default `--target`, so pushes don't need an explicit URL after the first jumpgate. Older specs that only have a top-level `"observablehq.com"` string are still honored as a fallback.
 
@@ -69,19 +75,66 @@ over an existing file to refresh **one** module also replaces everything else in
 
 - **The frame defaults to `@tomlarkworthy/lopepage`** — hash and theme come from the existing
   spec, the frame does not. Pass `--frame @tomlarkworthy/lopepage-2` when that is what the
-  notebook uses, or the layout regresses.
+  notebook uses, or the layout regresses. — *fixed 2026-08-13, see below.*
 - **Anything added to the HTML after the last export is dropped.** `@tomlarkworthy/save-in-place`
   — module block *and* its `mains` entry — is in the local file but in neither the Observable
   document nor the frame, so it vanished silently. The notebook still boots; it just loses
-  save-in-place.
+  save-in-place. — *fixed 2026-08-13 for anything named in `mains`; still true for a module
+  present in the HTML but absent from `mains`.*
 - **21 sibling modules were swapped for Observable's current copies**, drifting them off their
   declared canonicals (`lope-sync.ts audit` then showed this notebook as a population of one for
-  `lopepage-2`, `cell-map`, `exporter-3`, `themes`, `command-palette`, …).
+  `lopepage-2`, `cell-map`, `exporter-3`, `themes`, `command-palette`, …). — **still true.**
 
 So: to refresh one module from Observable, jumpgate to a **scratch path**, diff it
 (`lope-reader.ts --get-module` for the module, the `<script id>` set for blocks), then apply just
 that module with `sync-module`. Jumpgate in place only when the whole bundle is meant to be
-re-imported — and re-check `mains` and the frame afterwards.
+re-imported.
+
+#### 2026-08-13: mains and the frame now round-trip
+
+The first two bullets were one defect — `lope-jumpgate.js` never read `bootconf.mains`, so a
+regeneration declared exactly `[--frame, ...--source]` and silently dropped every other main.
+Reproduced on `@tomlarkworthy_cell-map.html` with the pre-fix tool:
+
+```
+recorded  ["@tomlarkworthy/lopepage-2","@tomlarkworthy/cell-map","@tomlarkworthy/save-in-place"]
+--source @tomlarkworthy/cell-map
+          ["@tomlarkworthy/lopepage",  "@tomlarkworthy/cell-map"]
+```
+
+Two losses in one run: the frame downgraded `lopepage-2` → `lopepage`, and `save-in-place` gone.
+`mains` now resolves into frame + sources — the `lopepage*` entry is the frame, the rest are
+sources — and the same command reproduces the recorded list exactly.
+
+**That works only because the spec is now maintained.** `mains` and `hash` are read from the
+`.json` sidecar, which had been written only by jumpgate while `save-in-place` and `sync-module`
+rewrote the HTML's `bootconf` block without touching it: on 2026-08-13, **187 of 229 specs recorded
+different `mains` than their own HTML**. `@tomlarkworthy_exporter-3.json` was the case that
+surfaced it, still carrying `observable_update_time` `2026-07-23T02:55:00.669Z` and
+`mains: ["lopepage","exporter-3"]` against an HTML reading
+`["lopepage-2","exporter-3","save-in-place"]`.
+
+So `bun tools/lope-sync.ts spec-sync` — already the `lope-spec-sync` pre-commit hook in both
+content repos — now resyncs `bootconf` from the HTML block alongside the module hashes, and the
+whole corpus was resynced in one pass. `theme` is preserved rather than overwritten: the exporter
+never writes one into the block (0 of 231 notebooks), so the spec is its only record. Measured the
+same day, `theme` is the **only** key the spec has and the HTML lacks, and the HTML has no key the
+spec lacks — which is what makes a whole-object merge faithful. All 205 recorded themes survived
+the resync.
+
+Verified by `--dry-run` (which prints the resolved frame/sources/mains without launching a browser)
+over all 229 notebooks with specs, after the resync: 212 reproduce their HTML's `mains` exactly, 14
+differ only by the frame moving to index 0 (set-identical — a jumpgate export has always emitted
+the frame first), **0 lose or gain a main**. Then a real browser export of `cell-map` reproduced
+`["lopepage-2","cell-map","save-in-place"]` and booted clean in headless Chromium.
+
+The three frame-only notebooks (`@tomlarkworthy_lopepage.html` ×2, `_lopepage-2.html`) have nothing
+but a frame in `mains`, so they still need an explicit `--source`:
+`Error: --source is required (no spec bootconf mains to derive it from)`.
+
+Carrying mains means carrying sources, so a multi-main notebook now fetches several Observable
+documents per export — the rate-limit hazard `lope-bulk-jumpgate` already hits. `--no-carry-mains`
+restores the old single-source behaviour, which is also how to export one source at a time.
 
 ### How lope-jumpgate.js Works Internally
 

--- a/tools/lope-jumpgate.js
+++ b/tools/lope-jumpgate.js
@@ -9,12 +9,15 @@
  *   node tools/lope-jumpgate.js --source @tomlarkworthy/exporter-2 --output path/to/output.html
  *
  * Options:
- *   --source <name>      Observable notebook shorthand (required)
- *   --frame <name>       Frame notebook shorthand (default: @tomlarkworthy/lopepage)
+ *   --source <name>      Observable notebook shorthand (default: from the existing spec's bootconf mains)
+ *   --frame <name>       Frame notebook shorthand (default: from the existing spec's bootconf mains,
+ *                        else @tomlarkworthy/lopepage)
  *   --jumpgate <path>    Path to jumpgate HTML (default: lopecode/notebooks/jumpgates.html)
  *   --output <path>      Where to write the exported HTML (required)
- *   --hash <hash>        Hash for bootconf (default: read from existing spec, or side-panel layout)
+ *   --hash <hash>        Hash for bootconf (default: read from the existing spec, or side-panel layout)
  *   --theme <name>       Theme name, e.g. near-midnight, midnight, parchment (default: from spec)
+ *   --no-carry-mains     Don't derive frame/sources from the existing spec's bootconf mains
+ *   --dry-run            Print the resolved frame/sources/mains as JSON and exit
  *   --timeout <ms>       Max wait for export (default: 120000)
  *   --headed             Show browser for debugging
  *   --verbose            Show browser console logs
@@ -43,6 +46,9 @@ function parseArgs(argv) {
     timeout: 120000,
     headed: false,
     verbose: false,
+    carryMains: true,
+    frameExplicit: false,
+    dryRun: false,
   };
 
   for (let i = 0; i < args.length; i++) {
@@ -52,6 +58,11 @@ function parseArgs(argv) {
       options.source = options.source ? `${options.source},${next}` : next;
     } else if (arg === '--frame' && args[i + 1]) {
       options.frame = args[++i];
+      options.frameExplicit = true;
+    } else if (arg === '--no-carry-mains') {
+      options.carryMains = false;
+    } else if (arg === '--dry-run') {
+      options.dryRun = true;
     } else if (arg === '--jumpgate' && args[i + 1]) {
       options.jumpgate = args[++i];
     } else if (arg === '--output' && args[i + 1]) {
@@ -74,15 +85,22 @@ Usage:
   node tools/lope-jumpgate.js --source <name> --output <path> [options]
 
 Options:
-  --source <name>      Observable notebook shorthand, e.g. @tomlarkworthy/exporter-2 (required).
+  --source <name>      Observable notebook shorthand, e.g. @tomlarkworthy/exporter-2.
                        Repeat --source or comma-separate to embed multiple primaries
                        in one bundle (--source @a/b --source @a/c, or --source @a/b,@a/c).
                        The first source is the primary (used for filename, title, default hash).
-  --frame <name>       Frame notebook shorthand (default: @tomlarkworthy/lopepage)
+                       Optional when --output names a notebook with an existing .json
+                       spec: the remaining sources are then read from its bootconf mains.
+  --frame <name>       Frame notebook shorthand (default: the lopepage variant recorded in
+                       the spec's bootconf mains, else @tomlarkworthy/lopepage)
   --jumpgate <path>    Path to jumpgate HTML (default: lopecode/notebooks/jumpgates.html)
   --output <path>      Where to write the exported HTML (required)
-  --hash <hash>        Hash for bootconf (default: read from existing spec, or side-panel layout)
+  --hash <hash>        Hash for bootconf (default: read from the existing spec, or side-panel layout)
   --theme <name>       Theme name, e.g. near-midnight, midnight, parchment (default: from spec or none)
+  --no-carry-mains     Don't derive frame/sources from the spec's bootconf mains. Use when
+                       deliberately narrowing what a notebook boots, or to export one
+                       source at a time when a multi-source run hits Observable's rate limit.
+  --dry-run            Print the resolved frame/sources/mains as JSON and exit
   --timeout <ms>       Max wait for export (default: 120000)
   --headed             Show browser for debugging
   --verbose            Show browser console logs
@@ -111,6 +129,21 @@ function log(msg) {
   process.stderr.write(`[lope-jumpgate] ${msg}\n`);
 }
 
+function readSpec(specPath) {
+  if (!fs.existsSync(specPath)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(specPath, 'utf-8'));
+  } catch (e) {
+    log(`Warning: failed to read existing spec: ${e.message}`);
+    return null;
+  }
+}
+
+// Which main is the frame. lopepage/lopepage-2 are the only frames in the corpus.
+function isFrameModule(name) {
+  return /(^|\/)lopepage(-\d+)?$/.test(name);
+}
+
 async function fetchObservableMetadata(observableUrl) {
   const prefix = 'https://observablehq.com/';
   if (!observableUrl.startsWith(prefix)) return null;
@@ -129,10 +162,6 @@ async function fetchObservableMetadata(observableUrl) {
 async function main() {
   const options = parseArgs(process.argv);
 
-  if (!options.source) {
-    console.error('Error: --source is required');
-    process.exit(1);
-  }
   if (!options.output) {
     console.error('Error: --output is required');
     process.exit(1);
@@ -151,9 +180,43 @@ async function main() {
     fs.mkdirSync(outputDir, { recursive: true });
   }
 
-  const sources = options.source.split(',').map(s => s.trim()).filter(Boolean);
+  // What the notebook currently boots. The sidecar's bootconf is kept in step with the
+  // HTML by the spec-sync pre-commit hook (`bun tools/lope-sync.ts spec-sync`).
+  const specPath = outputPath.replace(/\.html$/, '.json');
+  const spec = readSpec(specPath);
+  const priorBootconf = spec?.bootconf ?? null;
+  if (priorBootconf) {
+    log(`Prior bootconf: mains=${JSON.stringify(priorBootconf.mains ?? null)}`);
+  }
+
+  // Frame + sources: --flag > prior bootconf mains > defaults. An explicit --source stays
+  // primary (it drives title and the default hash); recorded mains are appended after it.
+  const sources = (options.source ?? '').split(',').map(s => s.trim()).filter(Boolean);
+  const priorMains = options.carryMains && Array.isArray(priorBootconf?.mains)
+    ? priorBootconf.mains
+    : [];
+  if (priorMains.length && !options.frameExplicit) {
+    const frames = priorMains.filter(isFrameModule);
+    if (frames.length === 1) {
+      options.frame = frames[0];
+      log(`Using frame from prior bootconf: ${options.frame}`);
+    } else if (frames.length > 1) {
+      log(`Warning: prior bootconf records ${frames.length} frames (${frames.join(', ')}); keeping --frame ${options.frame}`);
+    }
+  }
+  const frameName = toNotebookName(toFullUrl(options.frame));
+  if (priorMains.length) {
+    // Frames are never carried as sources — an explicit --frame swaps the recorded one out.
+    const carried = priorMains.filter(
+      name => !isFrameModule(name) && !sources.some(s => toNotebookName(toFullUrl(s)) === name)
+    );
+    if (carried.length) {
+      sources.push(...carried);
+      log(`Carrying ${carried.length} main(s) from prior bootconf: ${carried.join(', ')}`);
+    }
+  }
   if (sources.length === 0) {
-    console.error('Error: --source is required');
+    console.error('Error: --source is required (no spec bootconf mains to derive it from)');
     process.exit(1);
   }
   const sourceUrls = sources.map(toFullUrl);
@@ -162,24 +225,16 @@ async function main() {
   const primaryNotebook = sourceNotebooks[0];
   const frameUrl = toFullUrl(options.frame);
 
-  // Resolve hash and theme: --flag > existing spec > defaults
+  // Resolve hash and theme: --flag > prior bootconf > defaults.
   let hash = options.hash;
   let theme = options.theme;
-  const specPath = outputPath.replace(/\.html$/, '.json');
-  if ((!hash || !theme) && fs.existsSync(specPath)) {
-    try {
-      const spec = JSON.parse(fs.readFileSync(specPath, 'utf-8'));
-      if (!hash && spec.bootconf?.hash) {
-        hash = spec.bootconf.hash;
-        log(`Using hash from existing spec: ${hash}`);
-      }
-      if (!theme && spec.bootconf?.theme) {
-        theme = spec.bootconf.theme;
-        log(`Using theme from existing spec: ${theme}`);
-      }
-    } catch (e) {
-      log(`Warning: failed to read existing spec: ${e.message}`);
-    }
+  if (!hash && priorBootconf?.hash) {
+    hash = priorBootconf.hash;
+    log(`Using hash from prior bootconf: ${hash}`);
+  }
+  if (!theme && priorBootconf?.theme) {
+    theme = priorBootconf.theme;
+    log(`Using theme from prior bootconf: ${theme}`);
   }
   if (!hash) {
     hash = `#view=${encodeURI(
@@ -201,6 +256,19 @@ async function main() {
   log(`Frame: ${frameUrl}`);
   log(`Jumpgate: ${jumpgatePath}`);
   log(`Output: ${outputPath}`);
+
+  if (options.dryRun) {
+    // The mains the export would declare, in the order the jumpgate builds them.
+    // Deduped because the jumpgate keys them into a Map.
+    process.stdout.write(JSON.stringify({
+      frame: frameName,
+      sources: sourceNotebooks,
+      mains: [...new Set([frameName, ...sourceNotebooks])],
+      hash,
+      theme: theme ?? null,
+    }, null, 2) + '\n');
+    process.exit(0);
+  }
 
   // Launch browser
   const browser = await chromium.launch({

--- a/tools/lope-sync.ts
+++ b/tools/lope-sync.ts
@@ -86,6 +86,19 @@ export function blocksIn(html: string): Map<string, string> {
   return out;
 }
 
+/**
+ * The notebook's own `bootconf.json` block, or null. Last parseable block wins —
+ * the exporter modules carry the *template* for this block in their source, and
+ * that one has unresolved `${…}` so it never parses.
+ */
+export function bootconfIn(html: string): Record<string, unknown> | null {
+  let found: Record<string, unknown> | null = null;
+  for (const m of html.matchAll(/<script\s+id="bootconf\.json"[^>]*>([\s\S]*?)<\/script>/g)) {
+    try { found = JSON.parse(m[1].trim()); } catch { /* exporter template */ }
+  }
+  return found;
+}
+
 /** module id -> every notebook that embeds it. ~1.1s cold over the full corpus. */
 export function deriveIndex(): Map<string, BlockRef[]> {
   const idx = new Map<string, BlockRef[]>();
@@ -569,8 +582,19 @@ function cmdPrune(write: boolean): number {
  * establish on its own.
  *
  * Default scope is deliberately narrow, because the hook runs on every commit:
- * it restamps hashes for modules present in BOTH the spec and the HTML, and only
- * reports modules the spec has never heard of.
+ * it restamps hashes for modules present in BOTH the spec and the HTML, resyncs
+ * `bootconf` from the HTML block, and only reports modules the spec has never
+ * heard of.
+ *
+ * `bootconf` is in the default path because it is the half of the spec other
+ * tools *read*: `lope-jumpgate.js` takes `mains` and `hash` from it to decide
+ * what to re-export. Left unmaintained it went badly wrong — on 2026-08-13, 187
+ * of 229 specs recorded different `mains` than their own HTML, so a jumpgate
+ * regeneration silently dropped mains and downgraded the frame. `theme` is
+ * preserved rather than overwritten: the exporter never writes one into the
+ * block (0 of 231 notebooks), so the spec is its only record. Measured the same
+ * day, `theme` is the ONLY key the spec has and the HTML lacks, and the HTML has
+ * no key the spec lacks — so a whole-object merge is faithful.
  *
  * A notebook with NO spec fails rather than being skipped — otherwise the
  * invariant is silently optional and every new notebook opts out of it by
@@ -587,11 +611,10 @@ function cmdPrune(write: boolean): number {
  * shells out to that and merges the result. Slow (one runtime boot per
  * directory), hence opt-in rather than part of the hook.
  *
- * Rebuild takes ONLY `modules` from the regeneration. `bootconf` is not
- * derivable faithfully — parseNotebook reads the last `bootconf.json` block,
- * which for six notebooks lacks the `theme` the committed spec records — and
- * `upstreams` / `observable_version` / `observable_update_time` come from
- * ObservableHQ at jumpgate time. Those are preserved verbatim, as is key order.
+ * Rebuild takes ONLY `modules` from the regeneration — `bootconf` is handled on
+ * the default path above, and `upstreams` / `observable_version` /
+ * `observable_update_time` come from ObservableHQ at jumpgate time. Those are
+ * preserved verbatim, as is key order.
  */
 function freshSpecsByNotebook(dir: string): Map<string, any> {
   const out = execFileSync(
@@ -612,7 +635,7 @@ function cmdSpecSync(paths: string[], check: boolean, rebuild = false): number {
         return existsSync(d) ? readdirSync(d).filter((f) => f.endsWith(".html")).map((f) => join(d, f)) : [];
       });
 
-  let changedFiles = 0, changedEntries = 0, addedEntries = 0, createdFiles = 0;
+  let changedFiles = 0, changedEntries = 0, addedEntries = 0, createdFiles = 0, bootconfFiles = 0;
   const unlisted: string[] = [];
   const missingSpec: string[] = [];
 
@@ -660,8 +683,28 @@ function cmdSpecSync(paths: string[], check: boolean, rebuild = false): number {
     try { spec = JSON.parse(readFileSync(specPath, "utf8")); } catch { continue; }
     if (!spec.modules) continue;
 
-    const blocks = blocksIn(readFileSync(html, "utf8"));
+    const src = readFileSync(html, "utf8");
+    const blocks = blocksIn(src);
     let touched = 0;
+
+    // bootconf: the HTML is the live record — save-in-place and sync-module rewrite
+    // its block, and neither touches the spec. `theme` is the exception and is
+    // preserved: the exporter never writes one into the block (0 of 231 notebooks),
+    // so the spec is its only record. Measured 2026-08-13: `theme` is the ONLY key
+    // the spec has and the HTML lacks, and the HTML has no key the spec lacks.
+    let bootconfFixed = false;
+    const liveBootconf = bootconfIn(src);
+    if (liveBootconf) {
+      const merged: Record<string, unknown> = { ...liveBootconf };
+      for (const [k, v] of Object.entries(spec.bootconf ?? {})) {
+        if (!(k in merged)) merged[k] = v;
+      }
+      if (JSON.stringify(spec.bootconf ?? null) !== JSON.stringify(merged)) {
+        spec.bootconf = merged;
+        bootconfFixed = true;
+        touched++;
+      }
+    }
 
     if (rebuild) {
       const fresh = freshFor(html);
@@ -687,11 +730,13 @@ function cmdSpecSync(paths: string[], check: boolean, rebuild = false): number {
     if (!touched) continue;
     changedEntries += touched;
     changedFiles++;
+    if (bootconfFixed) bootconfFiles++;
+    const what = `${touched - (bootconfFixed ? 1 : 0)} hash(es)${bootconfFixed ? " + bootconf" : ""}`;
     if (check) {
-      console.error(`  STALE ${relative(ROOT, specPath)} (${touched} hash(es))`);
+      console.error(`  STALE ${relative(ROOT, specPath)} (${what})`);
     } else {
       writeFileSync(specPath, JSON.stringify(spec, null, 2) + "\n");
-      console.log(`  updated ${relative(ROOT, specPath)} (${touched} hash(es))`);
+      console.log(`  updated ${relative(ROOT, specPath)} (${what})`);
     }
   }
 
@@ -712,9 +757,11 @@ function cmdSpecSync(paths: string[], check: boolean, rebuild = false): number {
   if (changedFiles) {
     parts.push(
       check
-        ? `${changedEntries} stale hash(es) in ${changedFiles} spec(s)`
+        ? `${changedEntries} stale entr(ies) in ${changedFiles} spec(s)` +
+          (bootconfFiles ? ` (${bootconfFiles} bootconf)` : "")
         : `${changedEntries} change(s) in ${changedFiles} spec(s)` +
-          (addedEntries ? `, ${addedEntries} module entr(ies) added` : "")
+          (addedEntries ? `, ${addedEntries} module entr(ies) added` : "") +
+          (bootconfFiles ? `, ${bootconfFiles} bootconf(s) resynced` : "")
     );
   }
   if (parts.length) console.log(`\n${parts.join("; ")}${check ? ". Fix: bun tools/lope-sync.ts spec-sync" : " — re-stage them."}`);
@@ -745,11 +792,7 @@ function cmdInitCanonical(write: boolean): number {
   const mainsOf = (rel: string): string[] => {
     let m = mainsCache.get(rel);
     if (m) return m;
-    m = [];
-    const html = readFileSync(join(ROOT, rel), "utf8");
-    for (const b of html.matchAll(/<script\s+id="bootconf\.json"[^>]*>([\s\S]*?)<\/script>/g)) {
-      try { m = JSON.parse(b[1].trim()).mains ?? []; break; } catch { /* exporter template */ }
-    }
+    m = (bootconfIn(readFileSync(join(ROOT, rel), "utf8"))?.mains as string[]) ?? [];
     mainsCache.set(rel, m);
     return m;
   };


### PR DESCRIPTION
**This PR is a proposal.** Tool-only change in `tools/` plus the knowledge doc. Companion corpus PRs: **tomlarkworthy/lopecode#208** and **tomlarkworthy/lopebooks#122**.

Revised after review: the earlier version read the bootconf out of the HTML and treated the sidecar as untrustworthy. This one just uses the sidecar, and fixes the sidecar at the pre-commit boundary instead.

## Reported symptom

> The jumpgate gap — `lope-jumpgate.js` ignores `bootconf.mains` from the spec, and this notebook's `.json` is stale (July 23).

Two halves of one defect, now fixed at their own layers.

## Half one — lope-jumpgate ignored `mains`

It declared exactly `[--frame, ...--source]` and never read what the notebook already booted. Reproduced on `@tomlarkworthy_cell-map.html` with the pre-fix tool:

```
recorded  ["@tomlarkworthy/lopepage-2","@tomlarkworthy/cell-map","@tomlarkworthy/save-in-place"]
--source @tomlarkworthy/cell-map
          ["@tomlarkworthy/lopepage",  "@tomlarkworthy/cell-map"]
```

Frame downgraded `lopepage-2`→`lopepage`, `save-in-place` dropped. `knowledge/maintaining-...md` had both written down as separate standing hazards since 2026-08-02.

`mains` now resolves into frame + sources — the `lopepage*` entry is the frame, the rest are sources. `--source` stays primary (it drives title and default hash) with carried mains appended; an explicit `--frame` swaps the recorded frame out rather than adding it as a source.

## Half two — the spec was not maintained

Reading `mains` from the spec only works if the spec is right, and it was not. The spec is written only by jumpgate, while `save-in-place` and `sync-module` rewrite the HTML's bootconf block without touching it: **187 of 229 specs recorded different `mains` than their own HTML**. `@tomlarkworthy_exporter-3.json` is the case that surfaced this — `observable_update_time` `2026-07-23`, `mains: ["lopepage","exporter-3"]`, against an HTML reading `["lopepage-2","exporter-3","save-in-place"]`.

`bun tools/lope-sync.ts spec-sync` — already the `lope-spec-sync` pre-commit hook in both content repos — now resyncs `bootconf` from the HTML block alongside the module hashes. No new hook, no new tool: the commit boundary was already the synchronisation point, `bootconf` was just out of scope.

Its docstring had ruled `bootconf` out as "not derivable faithfully" because of `theme`. That is answered rather than worked around: `theme` is **preserved** instead of overwritten, and the whole-object merge is faithful because — measured 2026-08-13 — `theme` is the *only* key the spec has and the HTML lacks, and the HTML has no key the spec lacks.

## Verification

- **Corpus resync:** 188 specs updated (38 lopecode, 150 lopebooks). All **205** recorded themes survive. A second `spec-sync --check` pass over both reports `specs up to date` — idempotent.
- **`--dry-run` over all 229 notebooks with specs, after the resync:** 212 reproduce their HTML's `mains` exactly, 14 differ only by the frame moving to index 0 (set-identical — a jumpgate export has always emitted the frame first), **0 lose or gain a main**.
- **Real browser export** of `@tomlarkworthy_cell-map.html` to a scratch path reproduced `["lopepage-2","cell-map","save-in-place"]` and booted clean in headless Chromium (lopepage-2 chrome and cell-map content render; console errors none).
- **Hook end-to-end:** edited a notebook's bootconf block to add a main, ran the hook's own command — `1 bootconf(s) resynced — re-stage them`, exit non-zero, sidecar updated. (Note the hook's `test -f ../tools/lope-sync.ts || exit 0` guard silently no-ops inside a *worktree*, so it had to be run by path; it resolves normally in a real submodule checkout.)

## Blast radius

- Three frame-only notebooks (`@tomlarkworthy_lopepage.html` ×2, `_lopepage-2.html`) have nothing but a frame in `mains` and now need an explicit `--source`, with an error that says so.
- Carrying mains means carrying sources, so a multi-main export fetches several Observable documents — the rate-limit hazard `lope-bulk-jumpgate` already hits. `--no-carry-mains` restores the old behaviour and doubles as the way to export one source at a time.
- `spec-sync` now rewrites `bootconf` on any commit touching a notebook HTML, so specs will show bootconf churn where they previously showed only hash churn.
- The third hazard bullet in the knowledge doc is **unfixed and still true**: an in-place jumpgate still swaps sibling modules for Observable's current copies.

## Merge order

This PR carries the tool; the companions carry the corpus. The hook invokes the *parent* checkout's `tools/lope-sync.ts`, so bootconf maintenance only starts once this one is merged and the parent is fast-forwarded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)